### PR TITLE
Remove flask-restful (fixes #19)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -1,17 +1,26 @@
 """REST API blueprint."""
 
+from typing import Type
+
 from flask import Blueprint
-from flask_restful import Api
 
 from ..const import API_PREFIX
+from .resources.base import Resource
 from .resources.person import PeopleResource, PersonResource
 from .resources.token import TokenRefreshResource, TokenResource
 
+
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
-api = Api(api_blueprint)
 
 
-api.add_resource(PersonResource, "/person/<string:gramps_id>")
-api.add_resource(PeopleResource, "/person/")
-api.add_resource(TokenResource, "/login/")
-api.add_resource(TokenRefreshResource, "/refresh/")
+def register_endpt(resource: Type[Resource], url: str, name: str):
+    """Register an endpoint."""
+    api_blueprint.add_url_rule(url, view_func=resource.as_view(name))
+
+
+# Person
+register_endpt(PersonResource, "/person/<string:gramps_id>", "person")
+register_endpt(PeopleResource, "/person/", "people")
+# Token
+register_endpt(TokenResource, "/login/", "token")
+register_endpt(TokenRefreshResource, "/refresh/", "token_refresh")

--- a/gramps_webapi/api/resources/__init__.py
+++ b/gramps_webapi/api/resources/__init__.py
@@ -3,7 +3,7 @@
 from functools import wraps
 
 from flask import current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import (
     verify_jwt_in_request,
     verify_jwt_refresh_token_in_request,
@@ -34,13 +34,17 @@ def jwt_refresh_token_required_ifauth(func):
     return wrapper
 
 
+class Resource(MethodView):
+    """Base class for API resources."""
+
+
 class ProtectedResource(Resource):
     """Resource requiring JWT authentication."""
 
-    method_decorators = [jwt_required_ifauth]
+    decorators = [jwt_required_ifauth]
 
 
 class RefreshProtectedResource(Resource):
     """Resource requiring a JWT refresh token."""
 
-    method_decorators = [jwt_refresh_token_required_ifauth]
+    decorators = [jwt_refresh_token_required_ifauth]

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -3,12 +3,12 @@
 from abc import abstractmethod
 
 import gramps.gen.lib
-from flask_restful import Resource, abort
+from flask import abort, jsonify
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.db.dbconst import CLASS_TO_KEY_MAP, KEY_TO_NAME_MAP
 
 from ..util import get_dbstate
-from . import ProtectedResource
+from . import ProtectedResource, Resource
 
 
 class GrampsObjectResourceHelper:
@@ -70,7 +70,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         obj = self.get_object_from_gramps_id(gramps_id)
         if obj is None:
             return abort(404)
-        return self.object_to_dict_filtered(obj)
+        return jsonify(self.object_to_dict_filtered(obj))
 
 
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
@@ -78,10 +78,12 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
 
     def get(self):
         """Get all objects."""
-        return [
-            self.object_to_dict_filtered(obj)
-            for obj in self.db._iter_objects(self.object_class)
-        ]
+        return jsonify(
+            [
+                self.object_to_dict_filtered(obj)
+                for obj in self.db._iter_objects(self.object_class)
+            ]
+        )
 
 
 class GrampsObjectProtectedResource(GrampsObjectResource, ProtectedResource):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIREMENTS = [
     "Flask-Cors",
     "Flask-JWT-Extended",
     "Flask-Limiter",
-    "Flask-RESTful",
+    "webargs",
     "SQLAlchemy",
 ]
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -70,7 +70,7 @@ class TestPerson(unittest.TestCase):
     def test_token_endpoint(self):
         rv = self.client.post("/api/login/", data={})
         # no username or password provided
-        assert rv.status_code == 400
+        assert rv.status_code == 401
         rv = self.client.post("/api/login/", data={"username": "user", "password": 234})
         # wrong pw
         assert rv.status_code == 403


### PR DESCRIPTION
This fixes #19 by replacing `flask_restful` with `MethodView` and `reqparse` with `webargs`, as suggest by the `flask_restful` maintainer.