### PR TITLE
 Add gramps.example (work in progress) #5

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,38 @@
 """Unit test package for gramps_webapi."""
+
+import gzip
+import os
+import tempfile
+import unittest
+
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.db.utils import import_as_dict
+from gramps.gen.user import User
+from gramps.gen.utils.resourcepath import ResourcePath
+
+
+class ExampleDb:
+    """Gramps example database handler."""
+
+    def __init__(self) -> None:
+        """Initialize self."""
+        _resources = ResourcePath()
+        doc_dir = _resources.doc_dir
+        self.path_gz = os.path.join(doc_dir, "example", "gramps", "example.gramps.gz")
+        if not os.path.isfile(self.path_gz):
+            raise ValueError("example.gramps not found at {}".format(self.path_gz))
+        self.path = None
+
+    def load(self) -> DbReadBase:
+        """Extract the example DB to a temp file and return a DB instance."""
+        with gzip.open(self.path_gz, "rb") as f_gzip:
+            file_content = f_gzip.read()
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".gramps") as f:
+                f.write(file_content)
+                self.path = f.name
+        return import_as_dict(self.path, User())
+
+    def close(self) -> None:
+        """Delete the temporary file."""
+        if self.path is not None:
+            os.remove(self.path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,7 +40,7 @@ class ExampleDbBase:
                     " found at {}".format(os.path.dirname(self.path_gz))
                 )
             self.path = self._extract_to_tempfile()
-        self.tmp_dbdir: Optional[str] = None
+        self.tmp_dbdir = None
         self.old_path = None
 
     def _extract_to_tempfile(self) -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,21 +18,34 @@ class ExampleDb:
         """Initialize self."""
         _resources = ResourcePath()
         doc_dir = _resources.doc_dir
-        self.path_gz = os.path.join(doc_dir, "example", "gramps", "example.gramps.gz")
-        if not os.path.isfile(self.path_gz):
-            raise ValueError("example.gramps not found at {}".format(self.path_gz))
-        self.path = None
+        self.path = os.path.join(doc_dir, "example", "gramps", "example.gramps")
+        if os.path.isfile(self.path):
+            self.is_zipped = False
+        else:
+            self.is_zipped = True
+            self.path_gz = os.path.join(
+                doc_dir, "example", "gramps", "example.gramps.gz"
+            )
+            if not os.path.isfile(self.path_gz):
+                raise ValueError(
+                    "Neither example.gramps nor example.gramps.gz"
+                    " found at {}".format(os.path.dirname(self.path_gz))
+                )
+            self.path = self._extract_to_tempfile()
 
-    def load(self) -> DbReadBase:
-        """Extract the example DB to a temp file and return a DB instance."""
+    def _extract_to_tempfile(self) -> str:
+        """Extract the example DB to a temp file and return the path."""
         with gzip.open(self.path_gz, "rb") as f_gzip:
             file_content = f_gzip.read()
             with tempfile.NamedTemporaryFile(delete=False, suffix=".gramps") as f:
                 f.write(file_content)
-                self.path = f.name
+                return f.name
+
+    def load(self) -> DbReadBase:
+        """Return a DB instance with the Gramps example DB."""
         return import_as_dict(self.path, User())
 
     def close(self) -> None:
-        """Delete the temporary file."""
-        if self.path is not None:
+        """Delete the temporary file if the DB has been extracted."""
+        if self.is_zipped:
             os.remove(self.path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,17 +2,24 @@
 
 import gzip
 import os
+import shutil
 import tempfile
 import unittest
+from typing import Optional
 
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.config import get as getconfig
+from gramps.gen.config import set as setconfig
 from gramps.gen.db.base import DbReadBase
-from gramps.gen.db.utils import import_as_dict
+from gramps.gen.db.utils import import_as_dict, make_database
+from gramps.gen.dbstate import DbState
 from gramps.gen.user import User
 from gramps.gen.utils.resourcepath import ResourcePath
+from gramps.plugins.importer.importxml import importData
 
 
-class ExampleDb:
-    """Gramps example database handler."""
+class ExampleDbBase:
+    """Gramps example database handler base class."""
 
     def __init__(self) -> None:
         """Initialize self."""
@@ -23,6 +30,7 @@ class ExampleDb:
             self.is_zipped = False
         else:
             self.is_zipped = True
+            self.tmp_gzdir = tempfile.mkdtemp()
             self.path_gz = os.path.join(
                 doc_dir, "example", "gramps", "example.gramps.gz"
             )
@@ -32,20 +40,68 @@ class ExampleDb:
                     " found at {}".format(os.path.dirname(self.path_gz))
                 )
             self.path = self._extract_to_tempfile()
+        self.tmp_dbdir: Optional[str] = None
+        self.old_path = None
 
     def _extract_to_tempfile(self) -> str:
         """Extract the example DB to a temp file and return the path."""
         with gzip.open(self.path_gz, "rb") as f_gzip:
             file_content = f_gzip.read()
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".gramps") as f:
+            self.tmp_gzdir = tempfile.mkdtemp()
+            path = os.path.join(self.tmp_gzdir, "example.gramps")
+            with open(path, "wb") as f:
                 f.write(file_content)
-                return f.name
+            return path
+
+
+class ExampleDbInMemory(ExampleDbBase):
+    """Gramps in-memory example database handler.
+
+    Usage:
+    ```
+    exampledb = ExampleDbInMemory()
+    db = exampledb.load()
+    # ...
+    exampledb.close()
+    ```
+    """
 
     def load(self) -> DbReadBase:
-        """Return a DB instance with the Gramps example DB."""
+        """Return a DB instance with in-memory Gramps example DB."""
         return import_as_dict(self.path, User())
 
     def close(self) -> None:
         """Delete the temporary file if the DB has been extracted."""
         if self.is_zipped:
-            os.remove(self.path)
+            shutil.rmtree(self.tmp_gzdir)
+
+
+class ExampleDbSQLite(ExampleDbBase):
+    """Gramps SQLite example database handler.
+
+    Usage:
+    ```
+    exampledb = ExampleDbSQLite()
+    exampledb.write()
+    # ...
+    exampledb.delete()
+    ```
+
+    Between `write` and `delete`, the Gramps database path will be
+    changed to a temporary directory. The tree will be named "example".
+    """
+
+    def write(self) -> None:
+        """Write the example DB to a SQLite DB and change the DB path."""
+        self.tmp_dbdir = tempfile.mkdtemp()
+        self.old_path = getconfig("database.path")
+        setconfig("database.path", self.tmp_dbdir)
+        dbman = CLIDbManager(DbState())
+        dbman.import_new_db(self.path, User())
+
+    def delete(self) -> None:
+        """Change the DB path back and delete the SQLite DB."""
+        if self.tmp_dbdir:
+            shutil.rmtree(self.tmp_dbdir)
+        if self.old_path:
+            setconfig("database.path", self.old_path)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,8 +4,8 @@ import unittest
 from unittest.mock import patch
 
 from gramps.cli.clidbman import CLIDbManager
-from gramps.gen.db.utils import make_database
 from gramps.gen.dbstate import DbState
+
 from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_CONFIG
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,5 +9,6 @@ from . import ExampleDb
 
 class TestExampleDb(unittest.TestCase):
     def test_example_db(self):
-        db = ExampleDb().load()
-        self.assertIsInstance(db, DbReadBase)
+        db = ExampleDb()
+        self.assertIsInstance(db.load(), DbReadBase)
+        db.close()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,40 @@
 """Unit test package for gramps_webapi."""
 
+import os
 import unittest
 
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.config import get as getconfig
 from gramps.gen.db.base import DbReadBase
+from gramps.gen.dbstate import DbState
 
-from . import ExampleDb
+from . import ExampleDbInMemory, ExampleDbSQLite
 
 
 class TestExampleDb(unittest.TestCase):
-    def test_example_db(self):
-        db = ExampleDb()
+    """Test the example DB handlers."""
+
+    def test_example_db_inmemory(self):
+        """Test the in-memory example DB."""
+        db = ExampleDbInMemory()
         self.assertIsInstance(db.load(), DbReadBase)
         db.close()
+
+    def test_example_db_sqlite(self):
+        """Test the SQLite example DB."""
+        db = ExampleDbSQLite()
+        db.write()
+        self.assertEqual(getconfig("database.path"), db.tmp_dbdir)
+        dbman = CLIDbManager(DbState())
+        db_info = dbman.current_names
+        # there is only one DB here
+        self.assertEqual(len(db_info), 1)
+        # DB name
+        self.assertEqual(db_info[0][0], "example")
+        # DB path
+        self.assertEqual(os.path.dirname(db_info[0][1]), db.tmp_dbdir)
+        db.delete()
+        # just check that this is not at the tmp dir anymore
+        self.assertNotEqual(getconfig("database.path"), db.tmp_dbdir)
+        # ... and that the tmp dir is gone
+        self.assertTrue(not os.path.exists(db.tmp_dbdir))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,13 @@
+"""Unit test package for gramps_webapi."""
+
+import unittest
+
+from gramps.gen.db.base import DbReadBase
+
+from . import ExampleDb
+
+
+class TestExampleDb(unittest.TestCase):
+    def test_example_db(self):
+        db = ExampleDb().load()
+        self.assertIsInstance(db, DbReadBase)


### PR DESCRIPTION
This is a work in progress. The first commit finds the `gramps.example` from Gramps and loads it, returning a database instance to be used for unit test. (It takes the gzipped version from the `doc` folder and unzips it to a temporary file, since the ungzipped one from the `tests` folder that is used in the `gramps` unit tests is not available for an installed `gramps`.)

What is still missing is being able to use this also with unit tests that instantiate the app, in which case a "proper" file-based database is needed.

