### PR TITLE
Add filtering support, rename endpoints, refactor object extend (closes #17)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -10,6 +10,7 @@ from .resources.bookmark import BookmarkResource, BookmarksResource
 from .resources.citation import CitationResource, CitationsResource
 from .resources.event import EventResource, EventsResource
 from .resources.family import FamiliesResource, FamilyResource
+from .resources.filters import FilterResource
 from .resources.media import MediaObjectResource, MediaObjectsResource
 from .resources.metadata import MetadataResource
 from .resources.note import NoteResource, NotesResource
@@ -31,49 +32,51 @@ def register_endpt(resource: Type[Resource], url: str, name: str):
 
 
 # Person
-register_endpt(PersonResource, "/person/<string:handle>", "person")
-register_endpt(PeopleResource, "/person/", "people")
+register_endpt(PersonResource, "/people/<string:handle>", "person")
+register_endpt(PeopleResource, "/people/", "people")
 # Family
-register_endpt(FamilyResource, "/family/<string:handle>", "family")
-register_endpt(FamiliesResource, "/family/", "families")
+register_endpt(FamilyResource, "/families/<string:handle>", "family")
+register_endpt(FamiliesResource, "/families/", "families")
 # Source
-register_endpt(SourceResource, "/source/<string:handle>", "source")
-register_endpt(SourcesResource, "/source/", "sources")
+register_endpt(SourceResource, "/sources/<string:handle>", "source")
+register_endpt(SourcesResource, "/sources/", "sources")
 # Citation
-register_endpt(CitationResource, "/citation/<string:handle>", "citation")
-register_endpt(CitationsResource, "/citation/", "citations")
+register_endpt(CitationResource, "/citations/<string:handle>", "citation")
+register_endpt(CitationsResource, "/citations/", "citations")
 # Event
-register_endpt(EventResource, "/event/<string:handle>", "event")
-register_endpt(EventsResource, "/event/", "events")
+register_endpt(EventResource, "/events/<string:handle>", "event")
+register_endpt(EventsResource, "/events/", "events")
 # Media Object
 register_endpt(MediaObjectResource, "/media/<string:handle>", "media_object")
 register_endpt(MediaObjectsResource, "/media/", "media_objects")
 # Place
-register_endpt(PlaceResource, "/place/<string:handle>", "place")
-register_endpt(PlacesResource, "/place/", "places")
+register_endpt(PlaceResource, "/places/<string:handle>", "place")
+register_endpt(PlacesResource, "/places/", "places")
 # Repository
-register_endpt(RepositoryResource, "/repository/<string:handle>", "repository")
-register_endpt(RepositoriesResource, "/repository/", "repositories")
+register_endpt(RepositoryResource, "/repositories/<string:handle>", "repository")
+register_endpt(RepositoriesResource, "/repositories/", "repositories")
 # Note
-register_endpt(NoteResource, "/note/<string:handle>", "note")
-register_endpt(NotesResource, "/note/", "notes")
+register_endpt(NoteResource, "/notes/<string:handle>", "note")
+register_endpt(NotesResource, "/notes/", "notes")
 # Tag
-register_endpt(TagResource, "/tag/<string:handle>", "tag")
-register_endpt(TagsResource, "/tag/", "tags")
+register_endpt(TagResource, "/tags/<string:handle>", "tag")
+register_endpt(TagsResource, "/tags/", "tags")
 # Token
 register_endpt(TokenResource, "/login/", "token")
 register_endpt(TokenRefreshResource, "/refresh/", "token_refresh")
 # Bookmark
-register_endpt(BookmarkResource, "/bookmark/<string:category>", "bookmark")
-register_endpt(BookmarksResource, "/bookmark/", "bookmarks")
+register_endpt(BookmarkResource, "/bookmarks/<string:namespace>", "bookmark")
+register_endpt(BookmarksResource, "/bookmarks/", "bookmarks")
+# Filter
+register_endpt(FilterResource, "/filters/<string:namespace>", "filter")
 # Translate
-register_endpt(TranslationResource, "/translate/<string:code>", "translation")
-register_endpt(TranslationsResource, "/translate/", "translations")
+register_endpt(TranslationResource, "/translations/<string:code>", "translation")
+register_endpt(TranslationsResource, "/translations/", "translations")
 # Relation
 register_endpt(
     RelationResource,
-    "/relation/<string:handle1>/<string:handle2>",
-    "relation",
+    "/relations/<string:handle1>/<string:handle2>",
+    "relations",
 )
 # Metadata
 register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -97,12 +97,6 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             if obj is None:
                 abort(404)
             return self.response(200, [self.object_extend(obj, args)], args)
-        if "handle" in args:
-            try:
-                obj = self.get_object_from_handle(args["handle"])
-            except HandleError:
-                abort(404)
-            return self.response(200, [self.object_extend(obj, args)], args)
         query_method = self.db_handle.method(
             "get_%s_from_handle", self.gramps_class_name
         )

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -7,12 +7,14 @@ from flask import Response, abort
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
-from webargs import fields
+from webargs import fields, validate
 from webargs.flaskparser import use_args
 
 from ..util import get_dbstate
 from . import ProtectedResource, Resource
 from .emit import GrampsJSONEncoder
+from .filters import apply_filter
+from .util import get_extended_attributes
 
 
 class GrampsObjectResourceHelper(GrampsJSONEncoder):
@@ -23,9 +25,11 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
     def gramps_class_name(self):
         """To be set on child classes."""
 
-    @abstractmethod
     def object_extend(self, obj: GrampsObject, args: Dict) -> GrampsObject:
         """Extend the base object attributes as needed."""
+        if "extend" in args:
+            obj.extended = get_extended_attributes(self.db_handle, obj)
+        return obj
 
     @property
     def db_handle(self) -> DbReadBase:
@@ -52,11 +56,11 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
 
     @use_args(
         {
-            "strip": fields.Boolean(missing=False),
-            "keys": fields.DelimitedList(fields.Str()),
+            "strip": fields.Str(validate=validate.Length(equal=0)),
+            "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
-            "profile": fields.Boolean(missing=False),
-            "extend": fields.Boolean(missing=False),
+            "profile": fields.Str(validate=validate.Length(equal=0)),
+            "extend": fields.Str(validate=validate.Length(equal=0)),
         },
         location="query",
     )
@@ -65,8 +69,8 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         try:
             obj = self.get_object_from_handle(handle)
         except HandleError:
-            return abort(404)
-        return self.response(self.object_extend(obj, args), args)
+            abort(404)
+        return self.response(200, self.object_extend(obj, args), args)
 
 
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
@@ -74,13 +78,15 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
 
     @use_args(
         {
-            "gramps_id": fields.Str(),
-            "handle": fields.Str(),
-            "strip": fields.Boolean(missing=False),
-            "keys": fields.DelimitedList(fields.Str()),
+            "gramps_id": fields.Str(validate=validate.Length(min=1)),
+            "handle": fields.Str(validate=validate.Length(min=1)),
+            "strip": fields.Str(validate=validate.Length(equal=0)),
+            "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
-            "profile": fields.Boolean(missing=False),
-            "extend": fields.Boolean(missing=False),
+            "profile": fields.Str(validate=validate.Length(equal=0)),
+            "extend": fields.Str(validate=validate.Length(equal=0)),
+            "filter": fields.Str(validate=validate.Length(min=1)),
+            "rules": fields.Str(validate=validate.Length(min=1)),
         },
         location="query",
     )
@@ -89,19 +95,30 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
         if "gramps_id" in args:
             obj = self.get_object_from_gramps_id(args["gramps_id"])
             if obj is None:
-                return abort(404)
-            return self.response([self.object_extend(obj, args)], args)
+                abort(404)
+            return self.response(200, [self.object_extend(obj, args)], args)
         if "handle" in args:
             try:
                 obj = self.get_object_from_handle(args["handle"])
             except HandleError:
-                return abort(404)
-            return self.response([self.object_extend(obj, args)], args)
-        iter_method = self.db_handle.method("iter_%s_handles", self.gramps_class_name)
+                abort(404)
+            return self.response(200, [self.object_extend(obj, args)], args)
         query_method = self.db_handle.method(
             "get_%s_from_handle", self.gramps_class_name
         )
+        if "filter" in args or "rules" in args:
+            handle_list = apply_filter(self.db_handle, args, self.gramps_class_name)
+            return self.response(
+                200,
+                [
+                    self.object_extend(query_method(handle), args)
+                    for handle in handle_list
+                ],
+                args,
+            )
+        iter_method = self.db_handle.method("iter_%s_handles", self.gramps_class_name)
         return self.response(
+            200,
             [
                 self.object_extend(query_method(handle), args)
                 for handle in iter_method()

--- a/gramps_webapi/api/resources/bookmark.py
+++ b/gramps_webapi/api/resources/bookmark.py
@@ -16,30 +16,30 @@ class BookmarkResource(ProtectedResource, GrampsJSONEncoder):
         """Get the database instance."""
         return get_dbstate().db
 
-    def get(self, category: str) -> Response:
-        """Get list of bookmarks by category."""
+    def get(self, namespace: str) -> Response:
+        """Get list of bookmarks by namespace."""
         db_handle = self.db_handle
-        if category == "person":
+        if namespace == "people":
             result = db_handle.get_bookmarks()
-        elif category == "family":
+        elif namespace == "families":
             result = db_handle.get_family_bookmarks()
-        elif category == "media":
+        elif namespace == "media":
             result = db_handle.get_media_bookmarks()
-        elif category == "event":
+        elif namespace == "events":
             result = db_handle.get_event_bookmarks()
-        elif category == "citation":
+        elif namespace == "citations":
             result = db_handle.get_citation_bookmarks()
-        elif category == "note":
+        elif namespace == "notes":
             result = db_handle.get_note_bookmarks()
-        elif category == "place":
+        elif namespace == "places":
             result = db_handle.get_place_bookmarks()
-        elif category == "source":
+        elif namespace == "sources":
             result = db_handle.get_source_bookmarks()
-        elif category == "repository":
+        elif namespace == "repositories":
             result = db_handle.get_repo_bookmarks()
         else:
-            return abort(404)
-        return self.response(result)
+            abort(404)
+        return self.response(200, result)
 
 
 class BookmarksResource(ProtectedResource, GrampsJSONEncoder):
@@ -48,17 +48,18 @@ class BookmarksResource(ProtectedResource, GrampsJSONEncoder):
     def get(self) -> Response:
         """Get the list of bookmark types."""
         return self.response(
+            200,
             {
-                "categories": [
-                    "citation",
-                    "event",
-                    "family",
+                "namespaces": [
+                    "citations",
+                    "events",
+                    "families",
                     "media",
-                    "note",
-                    "person",
-                    "place",
-                    "repository",
-                    "source",
+                    "notes",
+                    "people",
+                    "places",
+                    "repositories",
+                    "sources",
                 ]
-            }
+            },
         )

--- a/gramps_webapi/api/resources/citation.py
+++ b/gramps_webapi/api/resources/citation.py
@@ -19,7 +19,7 @@ class CitationResourceHelper(GrampsObjectResourceHelper):
 
     def object_extend(self, obj: Citation, args: Dict) -> Citation:
         """Extend citation attributes as needed."""
-        if args["extend"]:
+        if "extend" in args:
             db_handle = self.db_handle
             obj.extended = get_extended_attributes(db_handle, obj)
             obj.extended["source"] = get_source_by_handle(db_handle, obj.source_handle)

--- a/gramps_webapi/api/resources/emit.py
+++ b/gramps_webapi/api/resources/emit.py
@@ -26,11 +26,14 @@ class GrampsJSONEncoder(JSONEncoder):
             getattr(lib, key) for key, value in inspect.getmembers(lib, inspect.isclass)
         ]
 
-    def response(self, payload: Any, args: Dict = {}) -> Response:
-        # pylint:disable=dangerous-default-value
+    def response(
+        self, status: int = 200, payload: Any = {}, args: Dict = {}
+    ) -> Response:
         """Prepare response."""
         if "strip" in args:
-            self.strip_empty_keys = args["strip"]
+            self.strip_empty_keys = True
+        else:
+            self.strip_empty_keys = False
         if "keys" in args:
             self.filter_only_keys = args["keys"]
         if "skipkeys" in args:
@@ -38,7 +41,7 @@ class GrampsJSONEncoder(JSONEncoder):
 
         return Response(
             response=self.encode(payload),
-            status=200,
+            status=status,
             mimetype="application/json",
         )
 

--- a/gramps_webapi/api/resources/emit.py
+++ b/gramps_webapi/api/resources/emit.py
@@ -1,7 +1,7 @@
 """Gramps Json Encoder."""
 
 import inspect
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import gramps.gen.lib as lib
 from flask import Response
@@ -27,9 +27,10 @@ class GrampsJSONEncoder(JSONEncoder):
         ]
 
     def response(
-        self, status: int = 200, payload: Any = {}, args: Dict = {}
+        self, status: int = 200, payload: Any = {}, args: Optional[Dict] = None
     ) -> Response:
         """Prepare response."""
+        args = args or {}
         if "strip" in args:
             self.strip_empty_keys = True
         else:

--- a/gramps_webapi/api/resources/event.py
+++ b/gramps_webapi/api/resources/event.py
@@ -24,9 +24,9 @@ class EventResourceHelper(GrampsObjectResourceHelper):
     def object_extend(self, obj: Event, args: Dict) -> Event:
         """Extend event attributes as needed."""
         db_handle = self.db_handle
-        if args["profile"]:
+        if "profile" in args:
             obj.profile = get_event_profile_for_object(db_handle, obj)
-        if args["extend"]:
+        if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj)
             obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
         return obj

--- a/gramps_webapi/api/resources/family.py
+++ b/gramps_webapi/api/resources/family.py
@@ -24,11 +24,11 @@ class FamilyResourceHelper(GrampsObjectResourceHelper):
     def object_extend(self, obj: Family, args: Dict) -> Family:
         """Extend family attributes as needed."""
         db_handle = self.db_handle
-        if args["profile"]:
+        if "profile" in args:
             obj.profile = get_family_profile_for_object(
                 db_handle, obj, with_events=True
             )
-        if args["extend"]:
+        if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj)
             obj.extended["father"] = get_person_by_handle(db_handle, obj.father_handle)
             obj.extended["mother"] = get_person_by_handle(db_handle, obj.mother_handle)

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -93,7 +93,7 @@ def build_filter(filter_parms: Dict, namespace: str, keys="short") -> GenericFil
             if rkey in filter_rule:
                 filter_regex = filter_rule[rkey]
         filter_object.add_rule(rule_instance(filter_args, use_regex=filter_regex))
-        return filter_object
+    return filter_object
 
 
 def apply_filter(db_handle: DbReadBase, args: Dict, namespace: str) -> List[Handle]:

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -271,7 +271,7 @@ class FilterResource(ProtectedResource, GrampsJSONEncoder):
         custom_filters = filters.CustomFilters.get_filters(namespace)
         for custom_filter in custom_filters:
             if args["name"] == custom_filter.get_name():
-                filter_set: Set[GenericFilter] = set()
+                filter_set = set()
                 self._find_dependent_filters(namespace, custom_filter, filter_set)
                 if len(filter_set) > 1:
                     if "force" not in args or not args["force"]:

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -106,7 +106,7 @@ def apply_filter(db_handle: DbReadBase, args: Dict, namespace: str) -> List[Hand
         abort(400)
 
     try:
-        filter_parms = QueryFilterSchema().load(json.loads(args["filters"]))
+        filter_parms = QueryFilterSchema().load(json.loads(args["rules"]))
     except json.JSONDecodeError:
         abort(400)
     except ValidationError:

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -1,0 +1,298 @@
+"""Gramps filter interface."""
+
+import json
+from typing import Dict, List, Set
+
+import gramps.gen.filters as filters
+from flask import Response, abort
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.filters import GenericFilter
+from marshmallow import Schema, ValidationError, fields
+from webargs import validate
+from webargs.flaskparser import use_args
+
+from ...const import GRAMPS_NAMESPACES
+from ...types import Handle
+from . import ProtectedResource
+from .emit import GrampsJSONEncoder
+
+_RULES_LOOKUP = {
+    "Person": filters.rules.person.editor_rule_list,
+    "Family": filters.rules.family.editor_rule_list,
+    "Event": filters.rules.event.editor_rule_list,
+    "Place": filters.rules.place.editor_rule_list,
+    "Citation": filters.rules.citation.editor_rule_list,
+    "Source": filters.rules.source.editor_rule_list,
+    "Repository": filters.rules.repository.editor_rule_list,
+    "Media": filters.rules.media.editor_rule_list,
+    "Note": filters.rules.note.editor_rule_list,
+}
+
+# The dict used to define a filter is structured with either short or long keys for
+# use in query parms or a post or put body as follows:
+#
+# {
+#     "n": name,              # Filter name
+#     "c": comment,           # Filter comment
+#     "f": function,          # Logical operation: 'and', 'or', 'xor', or 'one'
+#     "i": invert,            # Boolean indicator to invert result set, default False
+#     "r": [                  # List of rules to apply as part of the filter
+#         {
+#             "n": name,      # Class name of the rule
+#             "v": [],        # Values for the rule, default empty list
+#             "r": regex      # Boolean indicator to treat as regex, default False
+#         }
+#     ]
+# }
+
+_FILTER_KEYS = {
+    "short": {
+        "comment": "c",
+        "function": "f",
+        "invert": "i",
+        "name": "n",
+        "rules": "r",
+        "values": "v",
+    },
+    "long": {
+        "comment": "comment",
+        "function": "function",
+        "invert": "invert",
+        "name": "name",
+        "rules": "rules",
+        "values": "values",
+    },
+}
+
+
+def build_filter(filter_parms: Dict, namespace: str, keys="short") -> GenericFilter:
+    """Build and return a filter object."""
+    key = _FILTER_KEYS[keys]
+    filter_object = filters.GenericFilterFactory(namespace)()
+    if key["name"] in filter_parms:
+        filter_object.set_name(filter_parms[key["name"]])
+    if key["comment"] in filter_parms:
+        filter_object.set_comment(filter_parms[key["comment"]])
+    if key["function"] in filter_parms:
+        filter_object.set_logical_op(filter_parms[key["function"]])
+    if key["invert"] in filter_parms:
+        filter_object.set_invert(filter_parms[key["invert"]])
+    for filter_rule in filter_parms[key["rules"]]:
+        rule_instance = None
+        for rule_class in _RULES_LOOKUP[namespace]:
+            if filter_rule[key["name"]] == rule_class.__name__:
+                rule_instance = rule_class
+                break
+        if rule_instance is None:
+            abort(400)
+        filter_args = []
+        if key["values"] in filter_rule:
+            filter_args = filter_rule[key["values"]]
+        filter_regex = False
+        for rkey in ["r", "regex"]:
+            if rkey in filter_rule:
+                filter_regex = filter_rule[rkey]
+        filter_object.add_rule(rule_instance(filter_args, use_regex=filter_regex))
+        return filter_object
+
+
+def apply_filter(db_handle: DbReadBase, args: Dict, namespace: str) -> List[Handle]:
+    """Apply an existing or dynamically defined filter."""
+    filters.reload_custom_filters()
+    if args.get("filter"):
+        for filter_class in filters.CustomFilters.get_filters(namespace):
+            if args["filter"] == filter_class.get_name():
+                return filter_class.apply(db_handle)
+        abort(400)
+
+    try:
+        filter_parms = QueryFilterSchema().load(json.loads(args["filters"]))
+    except json.JSONDecodeError:
+        abort(400)
+    except ValidationError:
+        abort(400)
+
+    filter_object = build_filter(filter_parms, namespace, keys="short")
+    return filter_object.apply(db_handle)
+
+
+class RuleSchema(Schema):
+    """Structure for a rule."""
+
+    name = fields.Str(required=True, validate=validate.Length(min=1))
+    values = fields.List(fields.Raw, required=False)
+    regex = fields.Boolean(required=False, missing=False)
+
+
+class FilterSchema(Schema):
+    """Structure for a filter."""
+
+    name = fields.Str(required=True, validate=validate.Length(min=1))
+    comment = fields.Str(required=False)
+    function = fields.Str(
+        required=False,
+        missing="and",
+        validate=validate.OneOf(["and", "or", "xor", "one"]),
+    )
+    invert = fields.Boolean(required=False, missing=False)
+    rules = fields.List(fields.Nested(RuleSchema))
+
+
+class QueryRuleSchema(Schema):
+    """Structure for validating a rule embedded in query parms."""
+
+    n = fields.Str(required=True, validate=validate.Length(min=1))
+    v = fields.List(fields.Raw, required=False)
+    r = fields.Boolean(required=False, missing=False)
+
+
+class QueryFilterSchema(Schema):
+    """Structure for validating a filter embedded in query parms."""
+
+    f = fields.Str(
+        required=False,
+        missing="and",
+        validate=validate.OneOf(["and", "or", "xor", "one"]),
+    )
+    i = fields.Boolean(required=False, missing=False)
+    r = fields.List(fields.Nested(QueryRuleSchema))
+
+
+class FilterResource(ProtectedResource, GrampsJSONEncoder):
+    """Filter resource."""
+
+    @use_args(
+        {"filter": fields.Str(), "rule": fields.Str()},
+        location="query",
+    )
+    def get(self, args: Dict, namespace: str) -> Response:
+        """Get available custom filters and rules."""
+        try:
+            namespace = GRAMPS_NAMESPACES[namespace]
+        except KeyError:
+            abort(400)
+
+        rule_list = []
+        for rule_class in _RULES_LOOKUP[namespace]:
+            add_rule = True
+            if args.get("rule") and args["rule"] != rule_class.__name__:
+                add_rule = False
+            if add_rule:
+                rule_list.append(
+                    {
+                        "category": rule_class.category,
+                        "description": rule_class.description,
+                        "labels": rule_class.labels,
+                        "name": rule_class.name,
+                        "rule": rule_class.__name__,
+                    }
+                )
+        if args.get("rule") and not args.get("filter"):
+            return self.response(200, {"rules": rule_list})
+        filter_list = []
+        filters.reload_custom_filters()
+        for filter_class in filters.CustomFilters.get_filters(namespace):
+            add_filter = True
+            if args.get("filter") and args["filter"] != filter_class.get_name():
+                add_filter = False
+            if add_filter:
+                filter_list.append(
+                    {
+                        "comment": filter_class.get_comment(),
+                        "function": filter_class.get_logical_op(),
+                        "invert": filter_class.invert,
+                        "name": filter_class.get_name(),
+                        "rules": [
+                            {
+                                "name": filter_rule.__class__.__name__,
+                                "regex": filter_rule.use_regex,
+                                "values": filter_rule.values(),
+                            }
+                            for filter_rule in filter_class.get_rules()
+                        ],
+                    }
+                )
+        if args.get("filter") and not args.get("rule"):
+            return self.response(200, {"filters": filter_list})
+        return self.response(200, {"filters": filter_list, "rules": rule_list})
+
+    @use_args(FilterSchema(), location="json")
+    def post(self, args: Dict, namespace: str) -> Response:
+        """Create a custom filter."""
+        try:
+            namespace = GRAMPS_NAMESPACES[namespace]
+        except KeyError:
+            abort(404)
+
+        new_filter = build_filter(args, namespace, keys="long")
+        filters.reload_custom_filters()
+        for filter_rule in filters.CustomFilters.get_filters(namespace):
+            if new_filter.get_name() == filter_rule.get_name():
+                abort(422)
+        filters.CustomFilters.add(namespace, new_filter)
+        filters.CustomFilters.save()
+        return self.response(201, {"message": "Added filter: " + new_filter.get_name()})
+
+    @use_args(FilterSchema(), location="json")
+    def put(self, args: Dict, namespace: str) -> Response:
+        """Update a custom filter."""
+        try:
+            namespace = GRAMPS_NAMESPACES[namespace]
+        except KeyError:
+            abort(404)
+
+        new_filter = build_filter(args, namespace, keys="long")
+        filters.reload_custom_filters()
+        for filter_rule in filters.CustomFilters.get_filters(namespace):
+            if new_filter.get_name() == filter_rule.get_name():
+                filters.CustomFilters.get_filters(namespace).remove(filter_rule)
+                filters.CustomFilters.add(namespace, new_filter)
+                filters.CustomFilters.save()
+                return self.response(
+                    200, {"message": "Updated filter: " + new_filter.get_name()}
+                )
+        return abort(404)
+
+    @use_args(
+        {
+            "name": fields.Str(required=True),
+            "force": fields.Boolean(required=False, missing=False),
+        },
+        location="json",
+    )
+    def delete(self, args: Dict, namespace: str) -> Response:
+        """Delete a custom filter."""
+        try:
+            namespace = GRAMPS_NAMESPACES[namespace]
+        except KeyError:
+            abort(404)
+
+        filters.reload_custom_filters()
+        custom_filters = filters.CustomFilters.get_filters(namespace)
+        for custom_filter in custom_filters:
+            if args["name"] == custom_filter.get_name():
+                filter_set: Set[GenericFilter] = set()
+                self._find_dependent_filters(namespace, custom_filter, filter_set)
+                if len(filter_set) > 1:
+                    if "force" not in args or not args["force"]:
+                        abort(405)
+                list(map(custom_filters.remove, filter_set))
+                filters.CustomFilters.save()
+                return self.response(
+                    200, {"message": "Deleted filter: " + args["name"]}
+                )
+        return abort(404)
+
+    def _find_dependent_filters(
+        self, namespace: str, base_filter: GenericFilter, filter_set: Set[GenericFilter]
+    ):
+        """Recursively search for all dependent filters."""
+        base_filter_name = base_filter.get_name()
+        for custom_filter in filters.CustomFilters.get_filters(namespace):
+            if custom_filter.get_name() == base_filter_name:
+                continue
+            for custom_filter_rule in custom_filter.get_rules():
+                if base_filter_name in custom_filter_rule.values():
+                    self._find_dependent_filters(namespace, custom_filter, filter_set)
+                    break
+        filter_set.add(base_filter)

--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -1,28 +1,16 @@
 """Media API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Media
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes
 
 
 class MediaObjectResourceHelper(GrampsObjectResourceHelper):
     """Media resource helper."""
 
     gramps_class_name = "Media"
-
-    def object_extend(self, obj: Media, args: Dict) -> Media:
-        """Extend media attributes as needed."""
-        if args["extend"]:
-            db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-        return obj
 
 
 class MediaObjectResource(GrampsObjectProtectedResource, MediaObjectResourceHelper):

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -32,11 +32,11 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
             data = db_handle.get_summary()
             for item in data:
                 summary[item.replace(" ", "_").lower()] = data[item]
-            return self.response(summary)
+            return self.response(200, summary)
         if datatype == "researcher":
-            return self.response(db_handle.get_researcher())
+            return self.response(200, db_handle.get_researcher())
         if datatype == "surnames":
-            return self.response(db_handle.get_surname_list())
+            return self.response(200, db_handle.get_surname_list())
         if datatype == "types":
             if args.get("type"):
                 if args["type"] == "event_attribute":
@@ -72,7 +72,7 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
                 elif args["type"] == "place":
                     result = db_handle.get_place_types()
                 else:
-                    return abort(404)
+                    abort(404)
             else:
                 result = [
                     "event_attribute",
@@ -92,5 +92,5 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
                     "url",
                     "place",
                 ]
-            return self.response(result)
+            return self.response(200, result)
         abort(404)

--- a/gramps_webapi/api/resources/note.py
+++ b/gramps_webapi/api/resources/note.py
@@ -1,28 +1,16 @@
 """Note API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Note
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes
 
 
 class NoteResourceHelper(GrampsObjectResourceHelper):
     """Note resource helper."""
 
     gramps_class_name = "Note"
-
-    def object_extend(self, obj: Note, args: Dict) -> Note:
-        """Extend note attributes as needed."""
-        if args["extend"]:
-            db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-        return obj
 
 
 class NoteResource(GrampsObjectProtectedResource, NoteResourceHelper):

--- a/gramps_webapi/api/resources/person.py
+++ b/gramps_webapi/api/resources/person.py
@@ -24,11 +24,11 @@ class PersonResourceHelper(GrampsObjectResourceHelper):
     def object_extend(self, obj: Person, args: Dict) -> Person:
         """Extend person attributes as needed."""
         db_handle = self.db_handle
-        if args["profile"]:
+        if "profile" in args:
             obj.profile = get_person_profile_for_object(
                 db_handle, obj, with_family=True, with_events=True
             )
-        if args["extend"]:
+        if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj)
             obj.extended.update(
                 {

--- a/gramps_webapi/api/resources/place.py
+++ b/gramps_webapi/api/resources/place.py
@@ -1,28 +1,16 @@
 """Place API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Place
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes
 
 
 class PlaceResourceHelper(GrampsObjectResourceHelper):
     """Place resource helper."""
 
     gramps_class_name = "Place"
-
-    def object_extend(self, obj: Place, args: Dict) -> Place:
-        """Extend place attributes as needed."""
-        if args["extend"]:
-            db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-        return obj
 
 
 class PlaceResource(GrampsObjectProtectedResource, PlaceResourceHelper):

--- a/gramps_webapi/api/resources/relation.py
+++ b/gramps_webapi/api/resources/relation.py
@@ -54,13 +54,14 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
                     }
                 )
                 index = index + 1
-            return self.response(result)
+            return self.response(200, result)
 
         data = calc.get_one_relationship(db_handle, person1, person2, extra_info=True)
         return self.response(
+            200,
             {
                 "relationship_string": data[0],
                 "distance_common_origin": data[1],
                 "distance_common_other": data[2],
-            }
+            },
         )

--- a/gramps_webapi/api/resources/repository.py
+++ b/gramps_webapi/api/resources/repository.py
@@ -1,15 +1,10 @@
 """Repository API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Repository
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes
 
 
 class RepositoryResourceHelper(GrampsObjectResourceHelper):
@@ -17,16 +12,9 @@ class RepositoryResourceHelper(GrampsObjectResourceHelper):
 
     gramps_class_name = "Repository"
 
-    def object_extend(self, obj: Repository, args: Dict) -> Repository:
-        """Extend repository attributes as needed."""
-        if args["extend"]:
-            db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-        return obj
-
 
 class RepositoryResource(GrampsObjectProtectedResource, RepositoryResourceHelper):
-    """Tag resource."""
+    """Repository resource."""
 
 
 class RepositoriesResource(GrampsObjectsProtectedResource, RepositoryResourceHelper):

--- a/gramps_webapi/api/resources/source.py
+++ b/gramps_webapi/api/resources/source.py
@@ -1,28 +1,16 @@
 """Source API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Source
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes
 
 
 class SourceResourceHelper(GrampsObjectResourceHelper):
     """Source resource helper."""
 
     gramps_class_name = "Source"
-
-    def object_extend(self, obj: Source, args: Dict) -> Source:
-        """Extend source attributes as needed."""
-        if args["extend"]:
-            db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-        return obj
 
 
 class SourceResource(GrampsObjectProtectedResource, SourceResourceHelper):

--- a/gramps_webapi/api/resources/tag.py
+++ b/gramps_webapi/api/resources/tag.py
@@ -1,9 +1,5 @@
 """Tag API resource."""
 
-from typing import Dict
-
-from gramps.gen.lib import Tag
-
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
@@ -15,10 +11,6 @@ class TagResourceHelper(GrampsObjectResourceHelper):
     """Tag resource helper."""
 
     gramps_class_name = "Tag"
-
-    def object_extend(self, obj: Tag, args: Dict) -> Tag:
-        """Extend tag attributes as needed."""
-        return obj
 
 
 class TagResource(GrampsObjectProtectedResource, TagResourceHelper):

--- a/gramps_webapi/api/resources/translate.py
+++ b/gramps_webapi/api/resources/translate.py
@@ -29,10 +29,11 @@ class TranslationResource(ProtectedResource, GrampsJSONEncoder):
 
         gramps_locale = GrampsLocale(lang=code)
         return self.response(
+            200,
             [
                 {"original": s, "translation": gramps_locale.translation.sgettext(s)}
                 for s in strings
-            ]
+            ],
         )
 
 
@@ -43,5 +44,6 @@ class TranslationsResource(ProtectedResource, GrampsJSONEncoder):
         """Get available translations."""
         catalog = GRAMPS_LOCALE.get_language_dict()
         return self.response(
-            [{"language": language, "code": catalog[language]} for language in catalog]
+            200,
+            [{"language": language, "code": catalog[language]} for language in catalog],
         )

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -33,3 +33,16 @@ PRIMARY_GRAMPS_OBJECTS = {
     "Note": lib.Note,
     "Tag": lib.Tag,
 }
+
+# To map endpoints to Gramps objects
+GRAMPS_NAMESPACES = {
+    "people": "Person",
+    "families": "Family",
+    "events": "Event",
+    "places": "Place",
+    "citations": "Citation",
+    "sources": "Source",
+    "repositories": "Repository",
+    "media": "Media",
+    "notes": "Note",
+}

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -138,12 +138,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a person."
       - name: gramps_id
         in: query
         required: false
@@ -165,10 +159,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -177,10 +171,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -299,12 +293,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a family."
       - name: gramps_id
         in: query
         required: false
@@ -326,10 +314,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -338,10 +326,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -460,12 +448,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for an event."
       - name: gramps_id
         in: query
         required: false
@@ -487,10 +469,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -499,10 +481,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -621,12 +603,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a place."
       - name: gramps_id
         in: query
         required: false
@@ -648,10 +624,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -660,10 +636,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -768,12 +744,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 0
-        description: "The unique identifier for a citation."
       - name: gramps_id
         in: query
         required: false
@@ -795,10 +765,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -807,10 +777,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -915,12 +885,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a source."
       - name: gramps_id
         in: query
         required: false
@@ -942,10 +906,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -954,10 +918,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -1062,12 +1026,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a repository."
       - name: gramps_id
         in: query
         required: false
@@ -1089,10 +1047,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -1101,10 +1059,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -1209,12 +1167,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a media item."
       - name: gramps_id
         in: query
         required: false
@@ -1236,10 +1188,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -1248,10 +1200,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -1356,12 +1308,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a note."
       - name: gramps_id
         in: query
         required: false
@@ -1383,10 +1329,10 @@ paths:
           This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
 
 
-          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          The expression must be provided in JSON format and a number of fields are not required and have defaults if not present. The structure is defined as follows:
           
           
-          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          {"function": function, "invert": invert, "rules": [{"name": name, "values": [values], "regex": regex}]}
           
           
           The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
@@ -1395,10 +1341,10 @@ paths:
           The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
           
           
-          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          The rules consists of the list of rules to be evaluated. It is a mandatory field.
           
           
-          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          The name in a rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
           
           
           The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
@@ -1503,12 +1449,6 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: handle
-        in: query
-        required: false
-        type: string
-        minLength: 8
-        description: "The unique identifier for a tag."
       - name: strip
         in: query
         required: false
@@ -1667,6 +1607,16 @@ paths:
         required: true
         type: string
         description: "The namespace or category for the filters."
+      - name: rule
+        in: query
+        required: false
+        type: string
+        description: "The name of a specific filter rule to be returned."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of a specific custom filter to be returned."
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -27,31 +27,33 @@ securityDefinitions:
 tags:
 - name: authentication
   description: Access for presenting credentials.
-- name: person
+- name: people
   description: Access to person objects.
-- name: family
+- name: families
   description: Access to family objects.
-- name: event
+- name: events
   description: Access to event objects.
-- name: place
+- name: places
   description: Access to place objects.
-- name: citation
+- name: citations
   description: Access to citation objects.
-- name: source
+- name: sources
   description: Access to source objects.
-- name: repository
+- name: repositories
   description: Access to repository objects.
 - name: media
   description: Access to media objects.
-- name: note
+- name: notes
   description: Access to note objects.
-- name: tag
+- name: tags
   description: Access to tag objects.
-- name: bookmark
+- name: bookmarks
   description: Access to user bookmarks.
-- name: translate
+- name: filters
+  description: Access to filter management.
+- name: translations
   description: Access to translation service.
-- name: relation
+- name: relations
   description: Access to relationship calculator.
 - name: metadata
   description: Access to tree and application metadata.
@@ -124,13 +126,13 @@ paths:
           description: "Unprocessable Entity: Invalid token."
 
 ##############################################################################
-# Endpoint - Person
+# Endpoint - People
 ##############################################################################
 
-  /person:
+  /people:
     get:
       tags:
-      - person
+      - people
       summary: "Get information about multiple people."
       operationId: getPeople
       security:
@@ -140,17 +142,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a person."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a person, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -164,13 +207,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the person profile should be included in the response. The person profile contains summarized information about the person and their familial relationships in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the person profile should be included in the response. The person profile contains summarized information about the person and their familial relationships in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -183,10 +230,10 @@ paths:
         404:
           description: "Not Found: No people found."
 
-  /person/{handle}:
+  /people/{handle}:
     get:
       tags:
-      - person
+      - people
       summary: "Get information about a specific person."
       operationId: getPerson
       security:
@@ -196,12 +243,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a person."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -215,13 +265,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the person profile should be included in the response. The person profile contains summarized information about the person and their familial relationships in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the person profile should be included in the response. The person profile contains summarized information about the person and their familial relationships in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -233,13 +287,13 @@ paths:
           description: "Not Found: Person not found."
 
 ##############################################################################
-# Endpoint - Family
+# Endpoint - Families
 ##############################################################################
 
-  /family:
+  /families:
     get:
       tags:
-      - family
+      - families
       summary: "Get information about multiple families."
       operationId: getFamilies
       security:
@@ -249,17 +303,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a family."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a family, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -273,13 +368,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the family profile should be included in the response. The family profile contains summarized information about the family and their members in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the family profile should be included in the response. The family profile contains summarized information about the family and their members in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -292,10 +391,10 @@ paths:
         404:
           description: "Not Found: No families found."
 
-  /family/{handle}:
+  /families/{handle}:
     get:
       tags:
-      - family
+      - families
       summary: "Get information about a specific family."
       operationId: getFamily
       security:
@@ -305,12 +404,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a family."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates if keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -324,13 +426,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the family profile should be included in the response. The family profile contains summarized information about the family and their members in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the family profile should be included in the response. The family profile contains summarized information about the family and their members in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -342,13 +448,13 @@ paths:
           description: "Not Found: Family not found."
 
 ##############################################################################
-# Endpoint - Event
+# Endpoint - Events
 ##############################################################################
 
-  /event:
+  /events:
     get:
       tags:
-      - event
+      - events
       summary: "Get information about multiple events."
       operationId: getEvents
       security:
@@ -358,17 +464,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for an event."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for an event, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates if keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -382,13 +529,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the event profile should be included in the response. The event profile contains some brief information about the event in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the event profile should be included in the response. The event profile contains some brief information about the event in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -401,10 +552,10 @@ paths:
         404:
           description: "Not Found: No events found."
 
-  /event/{handle}:
+  /events/{handle}:
     get:
       tags:
-      - event
+      - events
       summary: "Get information about a specific event."
       operationId: getEvent
       security:
@@ -414,12 +565,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 0
         description: "The unique identifier for an event."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -433,13 +587,17 @@ paths:
       - name: profile
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the event profile should be included in the response. The event profile contains some brief information about the event in a more readily consumable format."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the event profile should be included in the response. The event profile contains some brief information about the event in a more readily consumable format."
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -451,13 +609,13 @@ paths:
           description: "Not Found: Event not found."
 
 ##############################################################################
-# Endpoint - Place
+# Endpoint - Places
 ##############################################################################
 
-  /place:
+  /places:
     get:
       tags:
-      - place
+      - places
       summary: "Get information about multiple places."
       operationId: getPlaces
       security:
@@ -467,17 +625,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a place."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a place, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -491,8 +690,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -505,10 +706,10 @@ paths:
         404:
           description: "Not Found: No places found."
 
-  /place/{handle}:
+  /places/{handle}:
     get:
       tags:
-      - place
+      - places
       summary: "Get information about a specific place."
       operationId: getPlace
       security:
@@ -518,12 +719,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a place."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -537,8 +741,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -550,13 +756,13 @@ paths:
           description: "Not Found: Place not found."
 
 ##############################################################################
-# Endpoint - Citation
+# Endpoint - Citations
 ##############################################################################
 
-  /citation:
+  /citations:
     get:
       tags:
-      - citation
+      - citations
       summary: "Get information about multiple citations."
       operationId: getCitations
       security:
@@ -566,17 +772,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 0
         description: "The unique identifier for a citation."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a citation, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -590,8 +837,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -604,10 +853,10 @@ paths:
         404:
           description: "Not Found: No citations found."
 
-  /citation/{handle}:
+  /citations/{handle}:
     get:
       tags:
-      - citation
+      - citations
       summary: "Get information about a specific citation."
       operationId: getCitation
       security:
@@ -617,12 +866,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a citation."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -636,8 +888,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -649,13 +903,13 @@ paths:
           description: "Not Found: Citation not found."
 
 ##############################################################################
-# Endpoint - Source
+# Endpoint - Sources
 ##############################################################################
 
-  /source:
+  /sources:
     get:
       tags:
-      - source
+      - sources
       summary: "Get information about multiple sources."
       operationId: getSources
       security:
@@ -665,17 +919,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a source."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a source, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -689,8 +984,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -703,10 +1000,10 @@ paths:
         404:
           description: "Not Found: No sources found."
 
-  /source/{handle}:
+  /sources/{handle}:
     get:
       tags:
-      - source
+      - sources
       summary: "Get information about a specific source."
       operationId: getSource
       security:
@@ -716,12 +1013,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a source."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -735,8 +1035,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -748,13 +1050,13 @@ paths:
           description: "Not Found: Source not found."
 
 ##############################################################################
-# Endpoint - Repository
+# Endpoint - Repositories
 ##############################################################################
 
-  /repository:
+  /repositories:
     get:
       tags:
-      - repository
+      - repositories
       summary: "Get information about multiple repositories."
       operationId: getRepositories
       security:
@@ -764,17 +1066,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a repository."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a repository, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -788,8 +1131,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -802,10 +1147,10 @@ paths:
         404:
           description: "Not Found: No repositories found."
 
-  /repository/{handle}:
+  /repositories/{handle}:
     get:
       tags:
-      - repository
+      - repositories
       summary: "Get information about a specific repository."
       operationId: getRepository
       security:
@@ -815,12 +1160,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a repository."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -834,8 +1182,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -863,17 +1213,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a media item."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a media item, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -887,8 +1278,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -914,12 +1307,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a media item."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -933,8 +1329,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -946,13 +1344,13 @@ paths:
           description: "Not Found: Media item not found."
 
 ##############################################################################
-# Endpoint - Note
+# Endpoint - Notes
 ##############################################################################
 
-  /note:
+  /notes:
     get:
       tags:
-      - note
+      - notes
       summary: "Get information about multiple notes."
       operationId: getNotes
       security:
@@ -962,17 +1360,58 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a note."
       - name: gramps_id
         in: query
         required: false
         type: string
         description: "An alternate user managed identifier for a note, usually but not guaranteed to be unique."
+      - name: filter
+        in: query
+        required: false
+        type: string
+        description: "The name of an existing custom filter to be used when generating the result set."
+      - name: rules
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined custom filter expression consisting of one of more filter rules to be used when generating the result set.
+
+
+          This filter is built and applied dynamically, it is not saved like a custom filter. It consists of one or more rules acting in combination, some of which can accept custom filters as arguments.
+
+
+          The expression must be provided in JSON format with abbreviated characters used in place of full keywords. A number of fields are not required and have defaults if not present. The structure is defined as follows:
+          
+          
+          {"f": function, "i": invert, "r": [{"n": name, "v": [values], "r": regex}]}
+          
+          
+          The function value is a string for the logical operation. Valid values are 'and', 'or', 'xor' and 'one'. If not present the default is 'and'.
+          
+          
+          The invert value is a boolean, true or false, that indicates if the results should be inverted. If not present the default is false.
+          
+          
+          The r indicates that the list provided is the list of rules to be evaluated. It is a mandatory field.
+          
+          
+          The name in the rule entry is the name of a predefined rule.  A list of rules with their names and descriptions can be obtained from the filters endpoint. It is a mandatory field.
+          
+          
+          The values list in the rule entry is optional and defaults to an empty list if not present.  Some rules take no arguments and others may take one or more arguments of different types that would need to be provided here.
+          
+          
+          The regex value is a boolean, true or false, that indicates if text values should be treated as regular expressions. If not present the default is false.
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -986,8 +1425,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1000,10 +1441,10 @@ paths:
         404:
           description: "Not Found: No notes found."
 
-  /note/{handle}:
+  /notes/{handle}:
     get:
       tags:
-      - note
+      - notes
       summary: "Get information about a specific note."
       operationId: getNote
       security:
@@ -1013,12 +1454,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a note."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -1032,8 +1476,10 @@ paths:
       - name: extend
         in: query
         required: false
-        type: boolean
-        description: "Indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        type: string
+        minLength: 0
+        maxLength: 0    
+        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1045,13 +1491,13 @@ paths:
           description: "Not Found: Note not found."
 
 ##############################################################################
-# Endpoint - Tag
+# Endpoint - Tags
 ##############################################################################
 
-  /tag:
+  /tags:
     get:
       tags:
-      - tag
+      - tags
       summary: "Get information about multiple tags."
       operationId: getTags
       security:
@@ -1061,12 +1507,15 @@ paths:
         in: query
         required: false
         type: string
+        minLength: 8
         description: "The unique identifier for a tag."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -1089,10 +1538,10 @@ paths:
         404:
           description: "Not Found: No tags found."
 
-  /tag/{handle}:
+  /tags/{handle}:
     get:
       tags:
-      - tag
+      - tags
       summary: "Get information about a specific tag."
       operationId: getTag
       security:
@@ -1102,12 +1551,15 @@ paths:
         in: path
         required: true
         type: string
+        minLength: 8
         description: "The unique identifier for a tag."
       - name: strip
         in: query
         required: false
-        type: boolean
-        description: "Indicates if keys with empty values should be stripped out of the response."
+        type: string
+        minLength: 0
+        maxLength: 0
+        description: "Presence indicates keys with empty values should be stripped out of the response."
       - name: keys
         in: query
         required: false
@@ -1129,13 +1581,13 @@ paths:
           description: "Not Found: Tag not found."
 
 ##############################################################################
-# Endpoint - Bookmark
+# Endpoint - Bookmarks
 ##############################################################################
 
-  /bookmark:
+  /bookmarks:
     get:
       tags:
-      - bookmark
+      - bookmarks
       summary: "Get a list of bookmark categories."
       operationId: getBookmarkCategories
       security:
@@ -1146,38 +1598,38 @@ paths:
           schema:
             type: object
             properties:
-              categories:
+              namespaces:
                 type: array
                 items:
                   type: string
             example:
-                categories:
-                - citation
-                - event
-                - family
+              namespaces:
+                - citations
+                - events
+                - families
                 - media
-                - note
-                - person
-                - place
-                - repository
-                - source
+                - notes
+                - people
+                - places
+                - repositories
+                - sources
         401:
           description: "Unauthorized: Missing authorization header."
 
-  /bookmark/{category}:
+  /bookmarks/{namespace}:
     get:
       tags:
-      - bookmark
+      - bookmarks
       summary: "Get bookmarks for a given category."
       operationId: getBookmarks
       security:
         - Bearer: []
       parameters:
-      - name: category
+      - name: namespace
         in: path
         required: true
         type: string
-        description: "The category for the bookmarks."
+        description: "The namespace or category for the bookmarks."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1198,13 +1650,131 @@ paths:
           description: "Not Found: Bookmark type not found."
 
 ##############################################################################
-# Endpoint - Translate
+# Endpoint - Filters
 ##############################################################################
-
-  /translate:
+        
+  /filters/{namespace}:
     get:
       tags:
-      - translate
+      - filters
+      summary: "Get custom filters and rules for a given namespace or category."
+      operationId: getFilters
+      security:
+        - Bearer: []
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        type: string
+        description: "The namespace or category for the filters."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: object
+            properties:
+              filters:
+                type: array
+                items:
+                  $ref: "#/definitions/CustomFilter"
+              rules:
+                type: array
+                items:
+                  $ref: "#/definitions/FilterRuleDescription"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Namespace not found."
+
+    post:
+      tags:
+      - filters
+      summary: "Create a custom filter."
+      operationId: createFilter
+      security:
+        - Bearer: []
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        type: string
+        description: "The namespace or category for the custom filter."
+      - name: filter
+        in: body
+        required: true
+        description: "The custom filter to create."
+        schema:
+          $ref: "#/definitions/CustomFilter"    
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing expected credentials."
+        403:
+          description: "Forbidden: Bad credentials, authentication failed."
+
+    put:
+      tags:
+      - filters
+      summary: "Update a custom filter."
+      operationId: updateFilter
+      security:
+        - Bearer: []
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        type: string
+        description: "The namespace or category for the custom filter."
+      - name: filter
+        in: body
+        required: true
+        description: "The custom filter to update."
+        schema:
+          $ref: "#/definitions/CustomFilter"    
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing expected credentials."
+        403:
+          description: "Forbidden: Bad credentials, authentication failed."
+
+    delete:
+      tags:
+      - filters
+      summary: "Delete a custom filter."
+      operationId: deleteFilter
+      security:
+        - Bearer: []
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        type: string
+        description: "The namespace or category for the custom filter."
+      - name: filter
+        in: body
+        required: true
+        description: "The custom filter to delete."
+        schema:
+          $ref: "#/definitions/CustomFilterObject"    
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing expected credentials."
+        403:
+          description: "Forbidden: Bad credentials, authentication failed."
+        
+##############################################################################
+# Endpoint - Translations
+##############################################################################
+
+  /translations:
+    get:
+      tags:
+      - translations
       summary: "Get information about available translations."
       operationId: getTranslations
       security:
@@ -1219,10 +1789,10 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
-  /translate/{code}:
+  /translations/{code}:
     get:
       tags:
-      - translate
+      - translations
       summary: "Get a translation in a specific language."
       operationId: getTranslation
       security:
@@ -1237,7 +1807,7 @@ paths:
         in: query
         required: true
         type: string
-        description: "The list of strings to be translated."
+        description: "The list of strings to be translated. These must be provided in JSON format."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1249,13 +1819,13 @@ paths:
           description: "Unauthorized: Missing authorization header."
 
 ##############################################################################
-# Endpoint - Relation
+# Endpoint - Relations
 ##############################################################################
 
-  /relation/{handle1}/{handle2}:
+  /relations/{handle1}/{handle2}:
     get:
       tags:
-      - relation
+      - relations
       summary: "Get relation between two people if one exists."
       operationId: getRelation
       security:
@@ -1305,9 +1875,7 @@ paths:
         200:
           description: "OK: Successful operation."
           schema:
-            type: object
-            items:
-              $ref: "#/definitions/TreeSummary"
+            $ref: "#/definitions/TreeSummary"
         401:
           description: "Unauthorized: Missing authorization header."
 
@@ -1323,9 +1891,7 @@ paths:
         200:
           description: "OK: Successful operation."
           schema:
-            type: object
-            items:
-              $ref: "#/definitions/TreeResearcher"
+            $ref: "#/definitions/TreeResearcher"
         401:
           description: "Unauthorized: Missing authorization header."
 
@@ -1597,7 +2163,7 @@ definitions:
   Person:
     type: object
     required:
-    - handle
+      - handle
     properties:
       address_list:
         description: "A list of addresses for the person if available."
@@ -1836,6 +2402,8 @@ definitions:
 
   PersonReference:
     type: object
+    required:
+      - ref
     properties:
       citation_list:
         description: "A list of handles for citations supporting the association."
@@ -2059,6 +2627,8 @@ definitions:
 
   ChildReference:
     type: object
+    required:
+      - ref
     properties:
       citation_list:
         description: "A list of handles for citations supporting the reference to the child in the family."
@@ -2234,6 +2804,8 @@ definitions:
 
   EventReference:
     type: object
+    required:
+      - ref
     properties:
       attribute_list:
         description: "A list of attributes related to the role of the person in the event."
@@ -2317,6 +2889,8 @@ definitions:
 
   Place:
     type: object
+    required:
+      - handle
     properties:
       alt_loc:
         description: "Alternate locations for the place."
@@ -2466,6 +3040,8 @@ definitions:
 
   PlaceReference:
     type: object
+    required:
+      - ref
     properties:
       date:
         description: "Date of the reference."
@@ -2592,6 +3168,7 @@ definitions:
     type: object
     required:
       - handle
+      - source_handle
     properties:
       attribute_list:
         description: "A list of attributes about the citation."
@@ -2795,6 +3372,8 @@ definitions:
     
   Repository:
     type: object
+    required:
+      - handle
     properties:
       address_list:
         description: "A list of addresses for the repository if available."
@@ -2874,6 +3453,8 @@ definitions:
     
   RepositoryReference:
     type: object
+    required:
+      - ref
     properties:
       call_number:
         description: "Call number for the source at the repository."
@@ -3010,6 +3591,8 @@ definitions:
 
   MediaReference:
     type: object
+    required:
+      - ref
     properties:
       attribute_list:
         description: "A list of attributes related to the media reference."
@@ -3156,6 +3739,8 @@ definitions:
 
   Tag:
     type: object
+    required:
+      - handle
     properties:
       change:
         description: "Time in epoch format the tag record was last modified."
@@ -3203,11 +3788,126 @@ definitions:
         example: "Web Home"
 
 ##############################################################################
+# Model - FilterRuleDescription
+##############################################################################
+
+  FilterRuleDescription:
+    type: object
+    required:
+       - labels
+       - name
+       - rule
+    properties:
+      category:
+        description: "The filter rule category."
+        type: string
+        example: "General filters"
+      description:
+        description: "A description of the filter rule."
+        type: string
+        example: "Matches people with the particular tag"
+      labels:
+        description: "A list of field labels for filter rules that take parameters."
+        type: array
+        items:
+          type: string
+        example:
+          - "Tag:"
+      name:
+        description: "A more concise rule description."
+        type: string
+        example: "People with the <tag>"
+      rule:
+        description: "The name of the filter rule."
+        type: string
+        example: "HasTag"
+
+##############################################################################
+# Model - FilterRule
+##############################################################################
+
+  FilterRule:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: "The name of the filter rule."
+        type: string
+        example: "HasTag"
+      regex:
+        description: "Indicator whether regular expressions used for text searches."
+        type: boolean
+        example: false
+      values:
+        description: "A list of values if the rule requires parameters."
+        type: array
+        items:
+          type: object
+        example:
+          - "Tag:"
+            
+##############################################################################
+# Model - CustomFilter
+##############################################################################
+
+  CustomFilter:
+    type: object
+    required:
+      - function
+      - invert
+      - name
+      - rules   
+    properties:
+      comment:
+        description: "A comment about purpose of the filter."
+        type: string
+        example: "All private males."
+      function:
+        description: "Logical operation to use in evaluating multiple rules. Must be 'and', 'or', 'xor' or 'one'"
+        type: string
+        example: "and"
+      invert:
+        description: "Indicator whether result set should be inverted."
+        type: boolean
+        example: false
+      name:
+        description: "The name of the custom filter."
+        type: string
+        example: "AllPrivateMales"
+      rules:
+        description: "The list of filter rules to apply as part of the filter."
+        type: array
+        items:
+          $ref: "#/definitions/FilterRule"
+
+##############################################################################
+# Model - CustomFilterObject    
+##############################################################################
+
+  CustomFilterObject:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        description: "Name of the custom rule to delete."
+        example: "MyTestRule"
+      force:
+        type: boolean
+        description: "Indicator to approve deletion of all dependent filters if any exist."
+        example: true
+                         
+##############################################################################
 # Model - Translations
 ##############################################################################
     
   Translations:
     type: object
+    required:
+      - code
+      - language
     properties:
       code:
         description: "The language code."

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -7,6 +7,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.db import DbTxn
 from gramps.gen.dbstate import DbState
 from gramps.gen.lib import Person, Surname
+
 from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
@@ -48,26 +49,26 @@ class TestPerson(unittest.TestCase):
         cls.dbman.remove_database(cls.name)
 
     def test_person_endpoint(self):
-        rv = self.client.get("/api/person/")
+        rv = self.client.get("/api/people/")
         # no authorization header!
         assert rv.status_code == 401
         # fetch a token and try again
         rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
         token = rv.json["access_token"]
         rv = self.client.get(
-            "/api/person/",
+            "/api/people/",
             headers={"Authorization": "Bearer {}".format(token)},
         )
         assert rv.status_code == 200
         it = rv.json[0]
-        rv = self.client.get("/api/person/" + it["handle"] + "?profile=1")
+        rv = self.client.get("/api/people/" + it["handle"] + "?profile")
         # no authorization header!
         assert rv.status_code == 401
         # fetch a token and try again
         rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
         token = rv.json["access_token"]
         rv = self.client.get(
-            "/api/person/" + it["handle"] + "?profile=1",
+            "/api/people/" + it["handle"] + "?profile",
             headers={"Authorization": "Bearer {}".format(token)},
         )
         assert rv.status_code == 200


### PR DESCRIPTION
@DavidMStraub @Nick-Hall I think this may be ready to merge if it passes muster. It does the following:

1. Renames all the endpoints to their plural form as they represent collections and not singular objects. Note I did not rename the source files in the resources directory, those are still singlar. ie person.py.
2. Adds support for the filtering framework by adding the /filters/{{namespace}} endpoint with the ability to get/create/update/delete custom filters and adding the filter= and rules= query parameters to the people, families, events, places, citations, sources, repositories, media and notes endpoints. filter= take the name of a custom filter. rules= takes a JSON structured argument to build a filter dynamically. 
3. Refactors object_extend to eliminate replicated code.
4. Refactors some of the boolean query parms into strings so the presence of the keyword is sufficient. ie profile, extend, strip.
5. Updates apispec.yaml to reflect the above changes and fix a couple issues.

This again tweaks the test cases to pass but does not add new ones. Once this is in and the example.gramps is merged I plan on focusing on test cases for everything done to date.