### PR TITLE
Refactor extend to accept keyword list, fix emit bug (Closes Issue #33)

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -60,7 +60,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
             "profile": fields.Str(validate=validate.Length(equal=0)),
-            "extend": fields.DelimitedList(fields.Str()),
+            "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
         },
         location="query",
     )
@@ -83,7 +83,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
             "profile": fields.Str(validate=validate.Length(equal=0)),
-            "extend": fields.DelimitedList(fields.Str()),
+            "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "filter": fields.Str(validate=validate.Length(min=1)),
             "rules": fields.Str(validate=validate.Length(min=1)),
         },

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -28,7 +28,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
     def object_extend(self, obj: GrampsObject, args: Dict) -> GrampsObject:
         """Extend the base object attributes as needed."""
         if "extend" in args:
-            obj.extended = get_extended_attributes(self.db_handle, obj)
+            obj.extended = get_extended_attributes(self.db_handle, obj, args)
         return obj
 
     @property
@@ -60,7 +60,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
             "profile": fields.Str(validate=validate.Length(equal=0)),
-            "extend": fields.Str(validate=validate.Length(equal=0)),
+            "extend": fields.DelimitedList(fields.Str()),
         },
         location="query",
     )
@@ -79,12 +79,11 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
     @use_args(
         {
             "gramps_id": fields.Str(validate=validate.Length(min=1)),
-            "handle": fields.Str(validate=validate.Length(min=1)),
             "strip": fields.Str(validate=validate.Length(equal=0)),
             "keys": fields.DelimitedList(fields.Str(), missing=[]),
             "skipkeys": fields.DelimitedList(fields.Str(), missing=[]),
             "profile": fields.Str(validate=validate.Length(equal=0)),
-            "extend": fields.Str(validate=validate.Length(equal=0)),
+            "extend": fields.DelimitedList(fields.Str()),
             "filter": fields.Str(validate=validate.Length(min=1)),
             "rules": fields.Str(validate=validate.Length(min=1)),
         },

--- a/gramps_webapi/api/resources/citation.py
+++ b/gramps_webapi/api/resources/citation.py
@@ -21,8 +21,15 @@ class CitationResourceHelper(GrampsObjectResourceHelper):
         """Extend citation attributes as needed."""
         if "extend" in args:
             db_handle = self.db_handle
-            obj.extended = get_extended_attributes(db_handle, obj)
-            obj.extended["source"] = get_source_by_handle(db_handle, obj.source_handle)
+            obj.extended = get_extended_attributes(db_handle, obj, args)
+            if (
+                "all" in args["extend"]
+                or "" in args["extend"]
+                or "source" in args["extend"]
+            ):
+                obj.extended["source"] = get_source_by_handle(
+                    db_handle, obj.source_handle, args
+                )
         return obj
 
 

--- a/gramps_webapi/api/resources/citation.py
+++ b/gramps_webapi/api/resources/citation.py
@@ -22,11 +22,7 @@ class CitationResourceHelper(GrampsObjectResourceHelper):
         if "extend" in args:
             db_handle = self.db_handle
             obj.extended = get_extended_attributes(db_handle, obj, args)
-            if (
-                "all" in args["extend"]
-                or "" in args["extend"]
-                or "source" in args["extend"]
-            ):
+            if "all" in args["extend"] or "source" in args["extend"]:
                 obj.extended["source"] = get_source_by_handle(
                     db_handle, obj.source_handle, args
                 )

--- a/gramps_webapi/api/resources/emit.py
+++ b/gramps_webapi/api/resources/emit.py
@@ -27,9 +27,13 @@ class GrampsJSONEncoder(JSONEncoder):
         ]
 
     def response(
-        self, status: int = 200, payload: Any = {}, args: Optional[Dict] = None
+        self,
+        status: int = 200,
+        payload: Optional[Any] = None,
+        args: Optional[Dict] = None,
     ) -> Response:
         """Prepare response."""
+        payload = payload or {}
         args = args or {}
         if "strip" in args:
             self.strip_empty_keys = True
@@ -37,8 +41,12 @@ class GrampsJSONEncoder(JSONEncoder):
             self.strip_empty_keys = False
         if "keys" in args:
             self.filter_only_keys = args["keys"]
+        else:
+            self.filter_only_keys = []
         if "skipkeys" in args:
             self.filter_skip_keys = args["skipkeys"]
+        else:
+            self.filter_skip_keys = []
 
         return Response(
             response=self.encode(payload),
@@ -68,6 +76,11 @@ class GrampsJSONEncoder(JSONEncoder):
         ):
             apply_filter = True
         for key, value in obj.__class__.__dict__.items():
+            if apply_filter:
+                if self.filter_only_keys and key not in self.filter_only_keys:
+                    continue
+                if self.filter_skip_keys and key in self.filter_skip_keys:
+                    continue
             if isinstance(value, property):
                 data[key] = getattr(obj, key)
         for key, value in obj.__dict__.items():

--- a/gramps_webapi/api/resources/event.py
+++ b/gramps_webapi/api/resources/event.py
@@ -28,11 +28,7 @@ class EventResourceHelper(GrampsObjectResourceHelper):
             obj.profile = get_event_profile_for_object(db_handle, obj)
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
-            if (
-                "all" in args["extend"]
-                or "" in args["extend"]
-                or "place" in args["extend"]
-            ):
+            if "all" in args["extend"] or "place" in args["extend"]:
                 obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
         return obj
 

--- a/gramps_webapi/api/resources/event.py
+++ b/gramps_webapi/api/resources/event.py
@@ -27,8 +27,13 @@ class EventResourceHelper(GrampsObjectResourceHelper):
         if "profile" in args:
             obj.profile = get_event_profile_for_object(db_handle, obj)
         if "extend" in args:
-            obj.extended = get_extended_attributes(db_handle, obj)
-            obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
+            obj.extended = get_extended_attributes(db_handle, obj, args)
+            if (
+                "all" in args["extend"]
+                or "" in args["extend"]
+                or "place" in args["extend"]
+            ):
+                obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
         return obj
 
 

--- a/gramps_webapi/api/resources/family.py
+++ b/gramps_webapi/api/resources/family.py
@@ -30,19 +30,11 @@ class FamilyResourceHelper(GrampsObjectResourceHelper):
             )
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
-            if (
-                "all" in args["extend"]
-                or "" in args["extend"]
-                or "father" in args["extend"]
-            ):
+            if "all" in args["extend"] or "father" in args["extend"]:
                 obj.extended["father"] = get_person_by_handle(
                     db_handle, obj.father_handle
                 )
-            if (
-                "all" in args["extend"]
-                or "" in args["extend"]
-                or "mother" in args["extend"]
-            ):
+            if "all" in args["extend"] or "mother" in args["extend"]:
                 obj.extended["mother"] = get_person_by_handle(
                     db_handle, obj.mother_handle
                 )

--- a/gramps_webapi/api/resources/family.py
+++ b/gramps_webapi/api/resources/family.py
@@ -29,9 +29,23 @@ class FamilyResourceHelper(GrampsObjectResourceHelper):
                 db_handle, obj, with_events=True
             )
         if "extend" in args:
-            obj.extended = get_extended_attributes(db_handle, obj)
-            obj.extended["father"] = get_person_by_handle(db_handle, obj.father_handle)
-            obj.extended["mother"] = get_person_by_handle(db_handle, obj.mother_handle)
+            obj.extended = get_extended_attributes(db_handle, obj, args)
+            if (
+                "all" in args["extend"]
+                or "" in args["extend"]
+                or "father" in args["extend"]
+            ):
+                obj.extended["father"] = get_person_by_handle(
+                    db_handle, obj.father_handle
+                )
+            if (
+                "all" in args["extend"]
+                or "" in args["extend"]
+                or "mother" in args["extend"]
+            ):
+                obj.extended["mother"] = get_person_by_handle(
+                    db_handle, obj.mother_handle
+                )
         return obj
 
 

--- a/gramps_webapi/api/resources/person.py
+++ b/gramps_webapi/api/resources/person.py
@@ -30,20 +30,17 @@ class PersonResourceHelper(GrampsObjectResourceHelper):
             )
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
-            do_all = False
-            if "all" in args["extend"] or "" in args["extend"]:
-                do_all = True
-            if do_all or "families" in args["extend"]:
+            if "all" in args["extend"] or "families" in args["extend"]:
                 obj.extended["families"] = [
                     get_family_by_handle(db_handle, handle)
                     for handle in obj.family_list
                 ]
-            if do_all or "parent_families" in args["extend"]:
+            if "all" in args["extend"] or "parent_families" in args["extend"]:
                 obj.extended["parent_families"] = [
                     get_family_by_handle(db_handle, handle)
                     for handle in obj.parent_family_list
                 ]
-            if do_all or "primary_parent_family" in args["extend"]:
+            if "all" in args["extend"] or "primary_parent_family" in args["extend"]:
                 obj.extended["primary_parent_family"] = get_family_by_handle(
                     db_handle, obj.get_main_parents_family_handle()
                 )

--- a/gramps_webapi/api/resources/person.py
+++ b/gramps_webapi/api/resources/person.py
@@ -29,22 +29,24 @@ class PersonResourceHelper(GrampsObjectResourceHelper):
                 db_handle, obj, with_family=True, with_events=True
             )
         if "extend" in args:
-            obj.extended = get_extended_attributes(db_handle, obj)
-            obj.extended.update(
-                {
-                    "families": [
-                        get_family_by_handle(db_handle, handle)
-                        for handle in obj.family_list
-                    ],
-                    "parent_families": [
-                        get_family_by_handle(db_handle, handle)
-                        for handle in obj.parent_family_list
-                    ],
-                    "primary_parent_family": get_family_by_handle(
-                        db_handle, obj.get_main_parents_family_handle()
-                    ),
-                }
-            )
+            obj.extended = get_extended_attributes(db_handle, obj, args)
+            do_all = False
+            if "all" in args["extend"] or "" in args["extend"]:
+                do_all = True
+            if do_all or "families" in args["extend"]:
+                obj.extended["families"] = [
+                    get_family_by_handle(db_handle, handle)
+                    for handle in obj.family_list
+                ]
+            if do_all or "parent_families" in args["extend"]:
+                obj.extended["parent_families"] = [
+                    get_family_by_handle(db_handle, handle)
+                    for handle in obj.parent_family_list
+                ]
+            if do_all or "primary_parent_family" in args["extend"]:
+                obj.extended["primary_parent_family"] = get_family_by_handle(
+                    db_handle, obj.get_main_parents_family_handle()
+                )
         return obj
 
 

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -41,24 +41,39 @@ def get_place_by_handle(db_handle: DbReadBase, handle: Handle) -> Optional[Place
 
 
 def get_family_by_handle(
-    db_handle: DbReadBase, handle: Handle, extended: bool = False
+    db_handle: DbReadBase, handle: Handle, args: Optional[Dict] = None
 ) -> Optional[Family]:
-    """Get a family and all extended attributes."""
+    """Get a family and optional extended attributes."""
     try:
         obj = db_handle.get_family_from_handle(handle)
     except HandleError:
         return None
-    if extended:
-        obj.extended = get_extended_attributes(db_handle, obj)
-        obj.extended["father"] = get_person_by_handle(db_handle, obj.father_handle)
-        obj.extended["mother"] = get_person_by_handle(db_handle, obj.mother_handle)
+    args = args or {}
+    if "extend" in args:
+        obj.extended = get_extended_attributes(db_handle, obj, args)
+        if (
+            "all" in args["extend"]
+            or "" in args["extend"]
+            or "father" in args["extend"]
+        ):
+            obj.extended["father"] = get_person_by_handle(db_handle, obj.father_handle)
+        if (
+            "all" in args["extend"]
+            or "" in args["extend"]
+            or "mother" in args["extend"]
+        ):
+            obj.extended["mother"] = get_person_by_handle(db_handle, obj.mother_handle)
     return obj
 
 
-def get_source_by_handle(db_handle: DbReadBase, handle: Handle) -> Source:
-    """Get a source and all extended attributes."""
+def get_source_by_handle(
+    db_handle: DbReadBase, handle: Handle, args: Optional[Dict] = None
+) -> Source:
+    """Get a source and optional extended attributes."""
+    args = args or {}
     obj = db_handle.get_source_from_handle(handle)
-    obj.extended = get_extended_attributes(db_handle, obj)
+    if "extend" in args:
+        obj.extended = get_extended_attributes(db_handle, obj, args)
     return obj
 
 
@@ -216,43 +231,55 @@ def get_family_profile_for_handle(
     return get_family_profile_for_object(db_handle, obj, with_events)
 
 
-def get_extended_attributes(db_handle: DbReadBase, obj: GrampsObject) -> Dict:
+def get_extended_attributes(
+    db_handle: DbReadBase, obj: GrampsObject, args: Optional[Dict] = None
+) -> Dict:
     """Get extended attributes for a GrampsObject."""
+    args = args or {}
     result = {}
-    if hasattr(obj, "child_ref_list"):
+    do_all = False
+    if "all" in args["extend"] or "" in args["extend"]:
+        do_all = True
+    if (do_all or "child_ref_list" in args["extend"]) and hasattr(
+        obj, "child_ref_list"
+    ):
         result["children"] = [
             db_handle.get_person_from_handle(child_ref.ref)
             for child_ref in obj.child_ref_list
         ]
-    if hasattr(obj, "citation_list"):
+    if (do_all or "citation_list" in args["extend"]) and hasattr(obj, "citation_list"):
         result["citations"] = [
             db_handle.get_citation_from_handle(handle) for handle in obj.citation_list
         ]
-    if hasattr(obj, "event_ref_list"):
+    if (do_all or "event_ref_list" in args["extend"]) and hasattr(
+        obj, "event_ref_list"
+    ):
         result["events"] = [
             db_handle.get_event_from_handle(event_ref.ref)
             for event_ref in obj.event_ref_list
         ]
-    if hasattr(obj, "media_list"):
+    if (do_all or "media_list" in args["extend"]) and hasattr(obj, "media_list"):
         result["media"] = [
             db_handle.get_media_from_handle(media_ref.ref)
             for media_ref in obj.media_list
         ]
-    if hasattr(obj, "note_list"):
+    if (do_all or "note_list" in args["extend"]) and hasattr(obj, "note_list"):
         result["notes"] = [
             db_handle.get_note_from_handle(handle) for handle in obj.note_list
         ]
-    if hasattr(obj, "person_ref_list"):
+    if (do_all or "person_ref_list" in args["extend"]) and hasattr(
+        obj, "person_ref_list"
+    ):
         result["people"] = [
             db_handle.get_person_from_handle(person_ref.ref)
             for person_ref in obj.person_ref_list
         ]
-    if hasattr(obj, "reporef_list"):
+    if (do_all or "reporef_list" in args["extend"]) and hasattr(obj, "reporef_list"):
         result["repositories"] = [
             db_handle.get_repository_from_handle(repo_ref.ref)
             for repo_ref in obj.reporef_list
         ]
-    if hasattr(obj, "tag_list"):
+    if (do_all or "tag_list" in args["extend"]) and hasattr(obj, "tag_list"):
         result["tags"] = [
             db_handle.get_tag_from_handle(handle) for handle in obj.tag_list
         ]

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -51,17 +51,9 @@ def get_family_by_handle(
     args = args or {}
     if "extend" in args:
         obj.extended = get_extended_attributes(db_handle, obj, args)
-        if (
-            "all" in args["extend"]
-            or "" in args["extend"]
-            or "father" in args["extend"]
-        ):
+        if "all" in args["extend"] or "father" in args["extend"]:
             obj.extended["father"] = get_person_by_handle(db_handle, obj.father_handle)
-        if (
-            "all" in args["extend"]
-            or "" in args["extend"]
-            or "mother" in args["extend"]
-        ):
+        if "all" in args["extend"] or "mother" in args["extend"]:
             obj.extended["mother"] = get_person_by_handle(db_handle, obj.mother_handle)
     return obj
 
@@ -238,7 +230,7 @@ def get_extended_attributes(
     args = args or {}
     result = {}
     do_all = False
-    if "all" in args["extend"] or "" in args["extend"]:
+    if "all" in args["extend"]:
         do_all = True
     if (do_all or "child_ref_list" in args["extend"]) and hasattr(
         obj, "child_ref_list"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -209,9 +209,26 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+    
+          For a person the possible keys are: 
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            event_ref_list | The list of referenced event records
+            families | The list of family records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            parent_families | The list of parent family records
+            person_ref_list | The list of referenced person records
+            primary_parent_family | The primary parent family record
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -267,9 +284,26 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a person the possible keys are: 
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            event_ref_list | The list of referenced event records
+            families | The list of family records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            parent_families | The list of parent family records
+            person_ref_list | The list of referenced person records
+            primary_parent_family | The primary parent family record
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -364,9 +398,25 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a family the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            child_ref_list | The list of referenced children records
+            citation_list | The list of citation records
+            event_ref_list | The list of referenced event records
+            father | The person record of the father
+            media_list | The list of referenced media items
+            mother | The person record of the mother
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -422,9 +472,25 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the notes records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a family the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            child_ref_list | The list of referenced children records
+            citation_list | The list of citation records
+            event_ref_list | The list of referenced event records
+            father | The person record of the father
+            media_list | The list of referenced media items
+            mother | The person record of the mother
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -519,9 +585,22 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For an event the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            place | The place record for the event
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -577,9 +656,22 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For an event the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            place | The place record for the event
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -667,9 +759,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a place the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -718,9 +822,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a place the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -808,9 +924,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a citation the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            source | The source record cited from
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -859,9 +987,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a citation the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            source | The source record cited from
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -949,9 +1089,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a source the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            reporef_list | The list of referenced repository records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1000,9 +1152,21 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a source the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            media_list | The list of referenced media items
+            note_list | The list of note records
+            reporef_list | The list of referenced repository records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1090,9 +1254,19 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a repository the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1141,9 +1315,19 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a repository the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1231,9 +1415,20 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a repository the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1282,9 +1477,20 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a repository the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            citation_list | The list of citation records
+            note_list | The list of note records
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1372,9 +1578,18 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a note the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."
@@ -1423,9 +1638,18 @@ paths:
         in: query
         required: false
         type: string
-        minLength: 0
-        maxLength: 0    
-        description: "Presence indicates that the attributes for referenced handles should be returned in the response. For example, while the note_list contains the handles of the note records, this will return the actual records in a separate extended section."
+        description: >
+          Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
+
+    
+          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
+
+
+          For a note the possible keys are:
+            Key | Records
+            --- | -------
+            all | Returns all possible records listed below
+            tag_list | The list of tags
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -213,10 +213,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-    
-          For a person the possible keys are: 
+          Accepts a comma delimited list of possible keys on which it will operate. For people the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -288,10 +285,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a person the possible keys are: 
+          Accepts a comma delimited list of keys on which it will operate. For a person the possible keys are: 
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -402,10 +396,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a family the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For families the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -476,10 +467,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a family the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a family the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -589,10 +577,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For an event the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For events the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -660,10 +645,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For an event the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For an event the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -763,10 +745,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a place the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For places the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -826,10 +805,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a place the possible keys are:
+          Accepts a list of comma delimited keys on which it will operate. For a place the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -928,10 +904,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a citation the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For citations the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -991,10 +964,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a citation the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a citation the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1093,10 +1063,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a source the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For sources the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1156,10 +1123,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a source the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a source the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1258,10 +1222,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a repository the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For repositories the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1319,10 +1280,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a repository the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a repository the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1419,10 +1377,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a repository the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For media items the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1481,10 +1436,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a repository the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a media item the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1582,10 +1534,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a note the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For notes the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below
@@ -1642,10 +1591,7 @@ paths:
           Enables the return of extended record information, allowing a client to fetch most of the available information for the object in one pass without having to perform multiple queries. These additional records are included under the top level 'extended' keyword in the response.
 
     
-          When provided by itself with no arguments the default behaviour is to return all of the available records. An optional comma delimited list of keys can be provided on which it will operate if only a subset of records is desired.
-
-
-          For a note the possible keys are:
+          Accepts a comma delimited list of keys on which it will operate. For a note the possible keys are:
             Key | Records
             --- | -------
             all | Returns all possible records listed below


### PR DESCRIPTION
This refactors the extend query parm itself so if provided with no args all records are returned as it currently behaves but if provided a comma delimited list of keywords only that subset is extracted and returned with the base record. Also fixes a missed case in emit with keys= handling.  The apispec.yaml has also been updated as appropriate.