### PR TITLE
WIP: media files (fixes #13).

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -3,6 +3,8 @@
 from typing import Type
 
 from flask import Blueprint, current_app
+from webargs import fields, validate
+from webargs.flaskparser import use_args
 
 from ..const import API_PREFIX
 from .auth import jwt_required_ifauth
@@ -24,6 +26,7 @@ from .resources.source import SourceResource, SourcesResource
 from .resources.tag import TagResource, TagsResource
 from .resources.token import TokenRefreshResource, TokenResource
 from .resources.translate import TranslationResource, TranslationsResource
+
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
 
@@ -89,3 +92,42 @@ def download_file(handle):
     base_dir = current_app.config["MEDIA_BASE_DIR"]
     handler = LocalFileHandler(handle, base_dir)
     return handler.send_file()
+
+
+# Media files
+@api_blueprint.route("/media/<string:handle>/thumbnail/<int:size>")
+@jwt_required_ifauth
+@use_args({"square": fields.Boolean(missing=False)}, location="query")
+def get_thumbnail(args, handle, size):
+    """Get a file's thumbnail."""
+    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    handler = LocalFileHandler(handle, base_dir)
+    return handler.send_thumbnail(size=size, square=args["square"])
+
+
+@api_blueprint.route(
+    "/media/<string:handle>/cropped/<int:x1>/<int:y1>/<int:x2>/<int:y2>"
+)
+@jwt_required_ifauth
+@use_args({"square": fields.Boolean(missing=False)}, location="query")
+def get_cropped(args, handle: str, x1: int, y1: int, x2: int, y2: int):
+    """Get the thumbnail of a cropped file."""
+    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    handler = LocalFileHandler(handle, base_dir)
+    return handler.send_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"])
+
+
+@api_blueprint.route(
+    "/media/<string:handle>/cropped/<int:x1>/<int:y1>/<int:x2>/<int:y2>/thumbnail/<int:size>"
+)
+@jwt_required_ifauth
+@use_args({"square": fields.Boolean(missing=False)}, location="query")
+def get_thumbnail_cropped(
+    args, handle: str, x1: int, y1: int, x2: int, y2: int, size: int
+):
+    """Get the thumbnail of a cropped file."""
+    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    handler = LocalFileHandler(handle, base_dir)
+    return handler.send_thumbnail_cropped(
+        size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"]
+    )

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -2,9 +2,11 @@
 
 from typing import Type
 
-from flask import Blueprint
+from flask import Blueprint, current_app
 
 from ..const import API_PREFIX
+from .auth import jwt_required_ifauth
+from .file import LocalFileHandler
 from .resources.base import Resource
 from .resources.bookmark import BookmarkResource, BookmarksResource
 from .resources.citation import CitationResource, CitationsResource
@@ -74,9 +76,16 @@ register_endpt(TranslationResource, "/translations/<string:isocode>", "translati
 register_endpt(TranslationsResource, "/translations/", "translations")
 # Relation
 register_endpt(
-    RelationResource,
-    "/relations/<string:handle1>/<string:handle2>",
-    "relations",
+    RelationResource, "/relations/<string:handle1>/<string:handle2>", "relations",
 )
 # Metadata
 register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")
+
+# Media files
+@api_blueprint.route("/media/<string:handle>/file")
+@jwt_required_ifauth
+def download_file(handle):
+    """Download a file."""
+    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    handler = LocalFileHandler(handle, base_dir)
+    return handler.send_file()

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -89,7 +89,7 @@ register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")
 @jwt_required_ifauth
 def download_file(handle):
     """Download a file."""
-    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    base_dir = current_app.config.get("MEDIA_BASE_DIR")
     handler = LocalFileHandler(handle, base_dir)
     return handler.send_file()
 
@@ -100,7 +100,7 @@ def download_file(handle):
 @use_args({"square": fields.Boolean(missing=False)}, location="query")
 def get_thumbnail(args, handle, size):
     """Get a file's thumbnail."""
-    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    base_dir = current_app.config.get("MEDIA_BASE_DIR")
     handler = LocalFileHandler(handle, base_dir)
     return handler.send_thumbnail(size=size, square=args["square"])
 
@@ -112,7 +112,7 @@ def get_thumbnail(args, handle, size):
 @use_args({"square": fields.Boolean(missing=False)}, location="query")
 def get_cropped(args, handle: str, x1: int, y1: int, x2: int, y2: int):
     """Get the thumbnail of a cropped file."""
-    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    base_dir = current_app.config.get("MEDIA_BASE_DIR")
     handler = LocalFileHandler(handle, base_dir)
     return handler.send_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"])
 
@@ -126,7 +126,7 @@ def get_thumbnail_cropped(
     args, handle: str, x1: int, y1: int, x2: int, y2: int, size: int
 ):
     """Get the thumbnail of a cropped file."""
-    base_dir = current_app.config["MEDIA_BASE_DIR"]
+    base_dir = current_app.config.get("MEDIA_BASE_DIR")
     handler = LocalFileHandler(handle, base_dir)
     return handler.send_thumbnail_cropped(
         size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"]

--- a/gramps_webapi/api/auth.py
+++ b/gramps_webapi/api/auth.py
@@ -1,0 +1,34 @@
+"""API resource endpoints."""
+
+from functools import wraps
+
+from flask import current_app
+from flask_jwt_extended import (
+    verify_jwt_in_request,
+    verify_jwt_refresh_token_in_request,
+)
+
+
+def jwt_required_ifauth(func):
+    """Check JWT unless authentication is disabled."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not current_app.config.get("DISABLE_AUTH"):
+            verify_jwt_in_request()
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def jwt_refresh_token_required_ifauth(func):
+    """Check JWT unless authentication is disabled."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not current_app.config.get("DISABLE_AUTH"):
+            verify_jwt_refresh_token_in_request()
+        return func(*args, **kwargs)
+
+    return wrapper
+

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -1,0 +1,52 @@
+"""File handling utilities."""
+
+import os
+
+from flask import send_from_directory
+from gramps.gen.lib import Media
+
+from .util import get_dbstate, get_media_base_dir
+
+
+class FileHandler:
+    """Generic media file handler."""
+
+    def __init__(self, handle):
+        """Initialize self."""
+        self.handle = handle
+        self.media = self._get_media_object()
+        self.mime = self.media.mime
+        self.path = self.media.path
+        self.checksum = self.media.checksum
+
+    def _get_media_object(self) -> Media:
+        """Get the media object from the database."""
+        dbstate = get_dbstate()
+        return dbstate.db.get_media_from_handle(self.handle)
+
+    def send_file(self):
+        """Send media file to client."""
+        raise NotImplementedError
+
+
+class LocalFileHandler(FileHandler):
+    """Handler for local files."""
+
+    def __init__(self, handle, base_dir=None):
+        """Initialize self given a handle and media base directory."""
+        super().__init__(handle)
+        self.base_dir = base_dir or get_media_base_dir()
+        if not os.path.isdir(self.base_dir):
+            raise ValueError("Directory {} does not exist".format(self.base_dir))
+        if os.path.isabs(self.path):
+            self.path_abs = self.path
+            self.path_rel = os.path.relpath(self.path, self.base_dir)
+        else:
+            self.path_abs = os.path.join(self.base_dir, self.path)
+            self.path_rel = self.path
+
+    def send_file(self):
+        """Send media file to client."""
+        return send_from_directory(
+            directory=self.base_dir, filename=self.path_rel, mimetype=self.mime
+        )

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -2,9 +2,12 @@
 
 import os
 
-from flask import send_from_directory
+from flask import send_file, send_from_directory
 from gramps.gen.lib import Media
 
+from gramps_webapi.const import MIME_JPEG
+
+from .image import ThumbnailHandler
 from .util import get_dbstate, get_media_base_dir
 
 
@@ -26,6 +29,16 @@ class FileHandler:
 
     def send_file(self):
         """Send media file to client."""
+        raise NotImplementedError
+
+    def send_thumbnail(self, size: int, square: bool = False):
+        """Send thumbnail of image."""
+        raise NotImplementedError
+
+    def send_thumbnail_cropped(
+        self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
+    ):
+        """Send thumbnail of cropped image."""
         raise NotImplementedError
 
 
@@ -50,3 +63,25 @@ class LocalFileHandler(FileHandler):
         return send_from_directory(
             directory=self.base_dir, filename=self.path_rel, mimetype=self.mime
         )
+
+    def send_cropped(self, x1: int, y1: int, x2: int, y2: int, square: bool = False):
+        """Send cropped image."""
+        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square)
+        return send_file(buffer, mimetype=MIME_JPEG)
+
+    def send_thumbnail(self, size: int, square: bool = False):
+        """Send thumbnail of image."""
+        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        buffer = thumb.get_thumbnail(size=size, square=square)
+        return send_file(buffer, mimetype=MIME_JPEG)
+
+    def send_thumbnail_cropped(
+        self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
+    ):
+        """Send thumbnail of cropped image."""
+        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        buffer = thumb.get_thumbnail_cropped(
+            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square
+        )
+        return send_file(buffer, mimetype=MIME_JPEG)

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -78,7 +78,7 @@ class ThumbnailHandler:
         else:
             if self.mime_type not in self.MIME_NO_IMAGE:
                 raise ValueError(
-                    f"No thumbnailer found for MIME type {self.mime_type}."
+                    "No thumbnailer found for MIME type {}.".format(self.mime_type)
                 )
             self.is_image = False
 

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -1,0 +1,136 @@
+"""Image utilities."""
+
+
+import io
+from pathlib import Path
+from typing import BinaryIO
+
+from pdf2image import convert_from_path
+from PIL import Image, ImageOps
+
+from gramps_webapi.const import MIME_PDF
+from gramps_webapi.types import FilenameOrPath
+
+
+def image_thumbnail(image: Image, size: int, square: bool = False) -> Image:
+    """Return a thumbnail of `size` (longest side) for the image.
+
+    If `square` is true, the image is cropped to a centered square.
+    """
+    if square:
+        # don't enlarge image: square size is at most shorter (!) side's length
+        size_orig = min(image.size)
+        size_square = min(size_orig, size)
+        return ImageOps.fit(
+            image,
+            (size_square, size_square),
+            bleed=0.0,
+            centering=(0.0, 0.5),
+            method=Image.BICUBIC,
+        )
+    img = image.copy()
+    img.thumbnail((size, size))
+    return img
+
+
+def image_square(image: Image) -> Image:
+    """Crop an image to a centered square."""
+    size = min(image.size)
+    return ImageOps.fit(
+        image, (size, size), bleed=0.0, centering=(0.0, 0.5), method=Image.BICUBIC,
+    )
+
+
+def crop_image(image: Image, x1: int, y1: int, x2: int, y2: int) -> Image:
+    """Crop an image.
+
+    The arguments `x1`, `y1`, `x2`, `y2` are the coordinates of the cropped region
+    in percent.
+    """
+    width, height = image.size
+    x1_abs = x1 * width / 100
+    x2_abs = x2 * width / 100
+    y1_abs = y1 * height / 100
+    y2_abs = y2 * height / 100
+    return image.crop((x1_abs, y1_abs, x2_abs, y2_abs))
+
+
+def save_image_buffer(image: Image, fmt="JPEG") -> BinaryIO:
+    """Save an image to a binary buffer."""
+    buffer = io.BytesIO()
+    image.save(buffer, format=fmt)
+    buffer.seek(0)
+    return buffer
+
+
+class ThumbnailHandler:
+    """Thumbnail handler."""
+
+    # supported MIME types that are not images
+    MIME_NO_IMAGE = [MIME_PDF]
+
+    def __init__(self, path: FilenameOrPath, mime_type: str) -> None:
+        """Initialize self given a path and MIME type."""
+        self.path = Path(path)
+        self.mime_type = mime_type
+        if self.mime_type.startswith("image/"):
+            self.is_image = True
+        else:
+            if self.mime_type not in self.MIME_NO_IMAGE:
+                raise ValueError(
+                    f"No thumbnailer found for MIME type {self.mime_type}."
+                )
+            self.is_image = False
+
+    def get_image(self) -> Image:
+        """Get a Pillow Image instance."""
+        if self.mime_type == MIME_PDF:
+            return self._get_image_pdf()
+        return Image.open(self.path)
+
+    def get_cropped(
+        self, x1: int, y1: int, x2: int, y2: int, square: bool = False
+    ) -> BinaryIO:
+        """Return a cropped version of the image at `path`.
+
+        The arguments `x1`, `y1`, `x2`, `y2` are the coordinates of the cropped region
+        in terms of the original image's coordinate system.
+
+        If `square` is true, the image is additionally cropped to a centered square.
+        """
+        img = self.get_image()
+        img = crop_image(img, x1, y1, x2, y2)
+        if square:
+            img = image_square(img)
+        return save_image_buffer(img)
+
+    def _get_image_pdf(self) -> Image:
+        """Get a Pillow Image instance of the PDF's first page."""
+        ims = convert_from_path(self.path, single_file=True, use_cropbox=True, dpi=100)
+        return ims[0]
+
+    def get_thumbnail(
+        self, size: int, square: bool = False, fmt: str = "JPEG"
+    ) -> BinaryIO:
+        """Return a thumbnail of `size` (longest side) for the image.
+
+        If `square` is true, the image is cropped to a centered square.
+        """
+        img = self.get_image()
+        img = image_thumbnail(image=img, size=size, square=square)
+        return save_image_buffer(img, fmt=fmt)
+
+    def get_thumbnail_cropped(
+        self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
+    ) -> BinaryIO:
+        """Return a cropped thumbnail of `size` (longest side) of the image at `path`.
+
+        The arguments `x1`, `y1`, `x2`, `y2` are the coordinates of the cropped region
+        in terms of the original image's coordinate system.
+
+        If `square` is true, the image is cropped to a centered square.
+        """
+        img = self.get_image()
+        img = crop_image(img, x1, y1, x2, y2)
+        img = image_thumbnail(image=img, size=size, square=square)
+        return save_image_buffer(img)

--- a/gramps_webapi/api/resources/__init__.py
+++ b/gramps_webapi/api/resources/__init__.py
@@ -1,35 +1,8 @@
 """API resource endpoints."""
 
-from functools import wraps
-
-from flask import current_app
 from flask.views import MethodView
-from flask_jwt_extended import (verify_jwt_in_request,
-                                verify_jwt_refresh_token_in_request)
 
-
-def jwt_required_ifauth(func):
-    """Check JWT unless authentication is disabled."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if not current_app.config.get("DISABLE_AUTH"):
-            verify_jwt_in_request()
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-def jwt_refresh_token_required_ifauth(func):
-    """Check JWT unless authentication is disabled."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if not current_app.config.get("DISABLE_AUTH"):
-            verify_jwt_refresh_token_in_request()
-        return func(*args, **kwargs)
-
-    return wrapper
+from ..auth import jwt_refresh_token_required_ifauth, jwt_required_ifauth
 
 
 class Resource(MethodView):

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -2,6 +2,7 @@
 
 
 from flask import current_app, g
+from gramps.gen.utils.file import expand_media_path
 
 from ..dbmanager import DbState
 
@@ -15,3 +16,9 @@ def get_dbstate() -> DbState:
     if "dbstate" not in g:
         g.dbstate = dbmgr.get_db()
     return g.dbstate
+
+
+def get_media_base_dir():
+    """Get the media base directory set in the database."""
+    db = get_dbstate()
+    return expand_media_path(db.get_mediapath(), db)

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -20,5 +20,5 @@ def get_dbstate() -> DbState:
 
 def get_media_base_dir():
     """Get the media base directory set in the database."""
-    db = get_dbstate()
+    db = get_dbstate().db
     return expand_media_path(db.get_mediapath(), db)

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -52,3 +52,7 @@ GRAMPS_NAMESPACES = {
     "media": "Media",
     "notes": "Note",
 }
+
+# MIME types
+MIME_PDF = "application/pdf"
+MIME_JPEG = "image/jpeg"

--- a/gramps_webapi/types.py
+++ b/gramps_webapi/types.py
@@ -1,6 +1,8 @@
 """Custom types."""
 
-from typing import NewType
+from pathlib import Path
+from typing import NewType, Union
 
 Handle = NewType("Handle", str)
 GrampsId = NewType("GrampsId", str)
+FilenameOrPath = Union[str, Path]

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ REQUIREMENTS = [
     "Flask-Limiter",
     "webargs",
     "SQLAlchemy",
+    "pdf2image",
+    "Pillow",
 ]
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 
 TEST_GRAMPSHOME = tempfile.mkdtemp()
 os.environ["GRAMPSHOME"] = TEST_GRAMPSHOME
@@ -32,6 +33,7 @@ class ExampleDbBase:
             os.makedirs(path, exist_ok=True)
         _resources = ResourcePath()
         doc_dir = _resources.doc_dir
+        os.environ["GRAMPS_RESOURCES"] = str(Path(_resources.data_dir).parent)
         self.path = os.path.join(doc_dir, "example", "gramps", "example.gramps")
         if os.path.isfile(self.path):
             self.is_zipped = False

--- a/tests/test_endpoints/test_file.py
+++ b/tests/test_endpoints/test_file.py
@@ -1,0 +1,172 @@
+"""Tests for the file and thumbnail endpoints using example_gramps."""
+
+import unittest
+from io import BytesIO
+
+from PIL import Image
+
+from gramps_webapi.const import MIME_JPEG
+
+from . import get_test_client
+
+
+class TestFile(unittest.TestCase):
+    """Test cases for the /api/media/{}/file endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_file_endpoint(self):
+        """Test reponse for files."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        assert len(media_objects) == 7
+        for obj in media_objects:
+            rv = self.client.get("/api/media/{}/file".format(obj["handle"]))
+            assert rv.mimetype == obj["mime"]
+
+
+class TestThumbnail(unittest.TestCase):
+    """Test cases for the /api/media/{}/thumbnail endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_thumbnail_endpoint_small(self):
+        """Test reponse for thumbnails."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            rv = self.client.get("/api/media/{}/thumbnail/20".format(obj["handle"]))
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            # long side should be 20 px
+            assert max(img.width, img.height) == 20
+
+    def test_thumbnail_endpoint_square(self):
+        """Test reponse for square thumbnails."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            rv = self.client.get(
+                "/api/media/{}/thumbnail/20?square=1".format(obj["handle"])
+            )
+            # should be small & square
+            img = Image.open(BytesIO(rv.data))
+            assert img.width == 20
+            assert img.height == 20
+
+    def test_thumbnail_endpoint_large(self):
+        """Test reponse for thumbnails (large)."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            # large thumb: return original image size
+            rv = self.client.get("/api/media/{}/file".format(obj["handle"]))
+            full_img = Image.open(BytesIO(rv.data))
+            rv = self.client.get("/api/media/{}/thumbnail/10000".format(obj["handle"]))
+            thumb = Image.open(BytesIO(rv.data))
+            assert full_img.width == thumb.width
+            assert full_img.height == thumb.height
+            # large square thumb: return cropped original image size
+            rv = self.client.get(
+                "/api/media/{}/thumbnail/10000?square=1".format(obj["handle"])
+            )
+            thumb = Image.open(BytesIO(rv.data))
+            assert thumb.width == thumb.height
+            assert min(full_img.width, full_img.height) == thumb.height
+
+
+class TestCropped(unittest.TestCase):
+    """Test cases for the /api/media/{}/cropped endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_cropped_endpoint(self):
+        """Test reponse for cropped image."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            rv = self.client.get("/api/media/{}/file".format(obj["handle"]))
+            full_img = Image.open(BytesIO(rv.data))
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/80/20/100".format(obj["handle"])
+            )
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            # allow 1 px difference due to rounding
+            self.assertAlmostEqual(img.width, 0.1 * full_img.width, delta=1)
+            self.assertAlmostEqual(img.height, 0.2 * full_img.height, delta=1)
+
+
+class TestCroppedThumbnail(unittest.TestCase):
+    """Test cases for the /api/media/{}/cropped/thumbnail endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_thumbnail_endpoint_small(self):
+        """Test reponse for thumbnails."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/10/90/90/thumbnail/20".format(obj["handle"])
+            )
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            # long side should be 20 px
+            assert max(img.width, img.height) == 20
+
+    def test_thumbnail_endpoint_square(self):
+        """Test reponse for square thumbnails."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/10/90/90/thumbnail/20?square=1".format(
+                    obj["handle"]
+                )
+            )
+            # should be small & square
+            img = Image.open(BytesIO(rv.data))
+            assert img.width == 20
+            assert img.height == 20
+
+    def test_thumbnail_endpoint_large(self):
+        """Test reponse for thumbnails (large)."""
+        # get all media handles
+        media_objects = self.client.get("/api/media/").json
+        for obj in media_objects:
+            # large thumb: return original image size
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/10/90/90".format(obj["handle"])
+            )
+            full_img = Image.open(BytesIO(rv.data))
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/10/90/90/thumbnail/10000".format(
+                    obj["handle"]
+                )
+            )
+            thumb = Image.open(BytesIO(rv.data))
+            assert full_img.width == thumb.width
+            assert full_img.height == thumb.height
+            # large square thumb: return cropped original image size
+            rv = self.client.get(
+                "/api/media/{}/cropped/10/10/90/90/thumbnail/10000?square=1".format(
+                    obj["handle"]
+                )
+            )
+            thumb = Image.open(BytesIO(rv.data))
+            assert thumb.width == thumb.height
+            assert min(full_img.width, full_img.height) == thumb.height
+


### PR DESCRIPTION
This is work in progress of implementing #13.

While I have been struggling with unit tests, I think I'll wait for @cdhorn's next PR and use the same approach :wink: 

Implemented so far: the endpoint `/api/media/somehandle/file` that simply downloads the file.

Implementation notes:

- The class `LocalFileHandler` inheriting from `FileHandler` might seem like overkill but it will allow generalizing this to cloud storage as done [here for S3](https://github.com/DavidMStraub/gramps-webapp/blob/master/gramps_webapp/media.py#L40-L116)
- When using local files, by using `flask.send_from_directory`, it is guaranteed that only files that are actually contained in the media base folder will be accessible. This prevents users from adding a media object with an absolute media path pointing to, say, `/etc/passwd`.
- The question is whether `MEDIA_BASE_DIR` *must* be specified or whether we should default to the directory in the Gramps settings. When using the API locally with an existing Gramps installation, that actually makes sense. When used on a server, it makes less sense.