### PR TITLE
Implement HTML note output (fixes #26)

### DIFF
--- a/gramps_webapi/api/html.py
+++ b/gramps_webapi/api/html.py
@@ -1,0 +1,119 @@
+"""HTML backend for styled text."""
+
+import bleach
+
+from gramps.gen.lib import Note, NoteType, StyledText
+from gramps.plugins.lib.libhtml import Html
+from gramps.plugins.lib.libhtmlbackend import HtmlBackend, process_spaces
+
+
+ALLOWED_TAGS = [
+    "a",
+    "abbr",
+    "acronym",
+    "b",
+    "blockquote",
+    "code",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "strong",
+    "ul",
+    "span",
+    "p",
+    "br",
+    "div",
+]
+
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "style"],
+    "abbr": ["title", "style"],
+    "acronym": ["title", "style"],
+    "p": ["style"],
+    "div": ["style"],
+    "span": ["style"],
+}
+
+ALLOWED_STYLES = [
+    "color",
+    "background-color",
+    "font-family",
+    "font-weight",
+    "font-size",
+    "font-style",
+    "text-decoration",
+]
+
+
+def sanitize(html: str):
+    """Sanitize an HTML string by keeping only allowed tags/attributes."""
+    return bleach.clean(
+        html,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        styles=ALLOWED_STYLES,
+        strip=True,
+    )
+
+
+def get_note_html(note: Note):
+    """Return a note text as sanitized HTML."""
+    html_note_text = styledtext_to_html(
+        styledtext=note.get_styledtext(),
+        space_format=note.get_format(),
+        contains_html=(note.get_type() == NoteType.HTML_CODE),
+    )
+    return sanitize(html_note_text)
+
+
+def styledtext_to_html(
+    styledtext: StyledText, space_format: int, contains_html: bool = False
+):
+    """Return the note in HTML format.
+
+    Adapted from DynamicWeb.
+    """
+    backend = HtmlBackend()
+
+    text = str(styledtext)
+
+    if not text:
+        return ""
+
+    s_tags = styledtext.get_tags()
+    html_list = Html("div", class_="grampsstylednote")
+    if contains_html:
+        markuptext = backend.add_markup_from_styled(
+            text, s_tags, split="\n", escape=False
+        )
+        html_list += markuptext
+    else:
+        markuptext = backend.add_markup_from_styled(text, s_tags, split="\n")
+        linelist = []
+        linenb = 1
+        sigcount = 0
+        for line in markuptext.split("\n"):
+            [line, sigcount] = process_spaces(line, format=space_format)
+            if sigcount == 0:
+                # The rendering of an empty paragraph '<p></p>'
+                # is undefined so we use a non-breaking space
+                if linenb == 1:
+                    linelist.append("&nbsp;")
+                html_list.extend(Html("p") + linelist)
+                linelist = []
+                linenb = 1
+            else:
+                if linenb > 1:
+                    linelist[-1] += "<br />"
+                linelist.append(line)
+                linenb += 1
+        if linenb > 1:
+            html_list.extend(Html("p") + linelist)
+        # if the last line was blank, then as well as outputting the previous para,
+        # which we have just done,
+        # we also output a new blank para
+        if sigcount == 0:
+            linelist = ["&nbsp;"]
+            html_list.extend(Html("p") + linelist)
+    return "\n".join(html_list)

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -63,6 +63,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             ),
             "profile": fields.Str(validate=validate.Length(equal=0)),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
+            "formats": fields.DelimitedList(fields.Str()),
         },
         location="query",
     )
@@ -90,6 +91,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "filter": fields.Str(validate=validate.Length(min=1)),
             "rules": fields.Str(validate=validate.Length(min=1)),
+            "formats": fields.DelimitedList(fields.Str()),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/note.py
+++ b/gramps_webapi/api/resources/note.py
@@ -4,13 +4,13 @@ from typing import Dict
 
 from gramps.gen.lib import Note
 
+from ..html import get_note_html
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-
-from ..html import get_note_html
+from .util import get_extended_attributes
 
 
 class NoteResourceHelper(GrampsObjectResourceHelper):
@@ -33,6 +33,8 @@ class NoteResourceHelper(GrampsObjectResourceHelper):
                 fmt: self.get_formatted_note(note=obj, fmt=fmt)
                 for fmt in formats_allowed
             }
+        if "extend" in args:
+            obj.extended = get_extended_attributes(self.db_handle, obj, args)
         return obj
 
     def get_formatted_note(self, note: Note, fmt: str) -> str:

--- a/gramps_webapi/api/resources/note.py
+++ b/gramps_webapi/api/resources/note.py
@@ -1,16 +1,45 @@
 """Note API resource."""
 
+from typing import Dict
+
+from gramps.gen.lib import Note
+
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
 
+from ..html import get_note_html
+
 
 class NoteResourceHelper(GrampsObjectResourceHelper):
     """Note resource helper."""
 
     gramps_class_name = "Note"
+
+    # supported formatted note formats (all lowercase!)
+    FORMATS_SUPPORTED = ["html"]
+
+    def object_extend(self, obj: Note, args: Dict) -> Note:
+        """Extend note attributes as needed."""
+        if "formats" in args:
+            formats_allowed = [
+                fmt.lower()
+                for fmt in args["formats"]
+                if fmt.lower() in set(self.FORMATS_SUPPORTED)
+            ]
+            obj.formatted = {
+                fmt: self.get_formatted_note(note=obj, fmt=fmt)
+                for fmt in formats_allowed
+            }
+        return obj
+
+    def get_formatted_note(self, note: Note, fmt: str) -> str:
+        """Get the note text in a specific format."""
+        if fmt.lower() == "html":
+            return get_note_html(note)
+        raise ValueError("Format {} not known or supported.".format(fmt))
 
 
 class NoteResource(GrampsObjectProtectedResource, NoteResourceHelper):

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ REQUIREMENTS = [
     "SQLAlchemy",
     "pdf2image",
     "Pillow",
+    "bleach",
 ]
 
 

--- a/tests/test_endpoints/test_notes.py
+++ b/tests/test_endpoints/test_notes.py
@@ -1,5 +1,6 @@
 """Tests for the /api/notes endpoints using example_gramps."""
 
+import re
 import unittest
 from typing import List
 
@@ -150,17 +151,13 @@ class TestNotesHandle(unittest.TestCase):
     def test_notes_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self,
-            "/api/notes/ac3804aac6b762b75a5",
-            ["handle", "text", "type"],
+            self, "/api/notes/ac3804aac6b762b75a5", ["handle", "text", "type"],
         )
 
     def test_notes_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self,
-            "/api/notes/ac3804aac6b762b75a5",
-            ["change", "format", "private"],
+            self, "/api/notes/ac3804aac6b762b75a5", ["change", "format", "private"],
         )
 
     def test_notes_handle_endpoint_extend(self):
@@ -180,3 +177,19 @@ class TestNotesHandle(unittest.TestCase):
             schema=API_SCHEMA["definitions"]["Note"],
             resolver=resolver,
         )
+
+    def test_notes_handle_endpoint_formats_html(self):
+        """Test response for formats parm."""
+        result = self.client.get("/api/notes/b39ff01f75c1f76859a?formats=html")
+        self.assertIn("formatted", result.json)
+        self.assertIn("html", result.json["formatted"])
+        html = result.json["formatted"]["html"]
+        self.assertIsInstance(html, str)
+        # strip tags
+        html_stripped = re.sub("<[^<]+?>", "", html)
+        # strip whitespace
+        html_stripped = re.sub(r"\s", "", html_stripped)
+        text_stripped = re.sub(r"\s", "", result.json["text"]["string"])
+        # the HTML stripped of tags should be equal to the pure text string,
+        # up to white space
+        assert text_stripped == html_stripped


### PR DESCRIPTION
As discussed in #26, I added HTML note output to the `/notes/` endpoint. The code is mostly taken from `gramps_webapp`, which in turn is partly taken from the narrative web plugin.

API details:
- Input: `/api/notes/?formats=html`, `/api/notes/myhandle/?formats=html` where `formats` can be a comma-delimited list in the future.
- Output: a key `formatted` is added to the output, which in turn contains a key `html` with the escaped HTML string (and possibly other formats in the future)

Implementation details:
- I added the `formats` key to the base object, even though it has no effect on any other endpoint. I did this mostly because I couldn't think of a better way to do it (which for sure doesn't mean there is none)
- The HTML output is sanitized with a white list of tags, attributes, and styles, to prevent security issues in web apps through injected Javascript etc. This could potentially become configurable through query arguments in the future, although I don't really see the need at the moment

Open issues:
- unit tests missing