### PR TITLE
Refactor GRAMPSHOME to fix singletons

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,8 +6,6 @@ import shutil
 import tempfile
 import unittest
 
-global TEST_GRAMPSHOME
-
 TEST_GRAMPSHOME = tempfile.mkdtemp()
 os.environ["GRAMPSHOME"] = TEST_GRAMPSHOME
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,17 +1,21 @@
 """Unit test package for gramps_webapi."""
 
 import gzip
-import importlib
 import os
 import shutil
 import tempfile
 import unittest
-from typing import Optional
 
-import gramps.cli.clidbman
-import gramps.cli.grampscli
+global TEST_GRAMPSHOME
+
+TEST_GRAMPSHOME = tempfile.mkdtemp()
+os.environ["GRAMPSHOME"] = TEST_GRAMPSHOME
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.cli.grampscli import CLIManager
 from gramps.gen.config import get as getconfig
 from gramps.gen.config import set as setconfig
+from gramps.gen.const import USER_DIRLIST
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.db.utils import import_as_dict, make_database
 from gramps.gen.dbstate import DbState
@@ -26,6 +30,8 @@ class ExampleDbBase:
 
     def __init__(self) -> None:
         """Initialize self."""
+        for path in USER_DIRLIST:
+            os.makedirs(path, exist_ok=True)
         _resources = ResourcePath()
         doc_dir = _resources.doc_dir
         self.path = os.path.join(doc_dir, "example", "gramps", "example.gramps")
@@ -43,8 +49,6 @@ class ExampleDbBase:
                     " found at {}".format(os.path.dirname(self.path_gz))
                 )
             self.path = self._extract_to_tempfile()
-        self.tmp_dbdir = None
-        self.old_path = None
 
     def _extract_to_tempfile(self) -> str:
         """Extract the example DB to a temp file and return the path."""
@@ -88,25 +92,17 @@ class ExampleDbSQLite(ExampleDbBase, WebDbManager):
     app = create_app(db_manager = exampledb)
     ```
 
-    Instantiation should occur during test fixture setup, at which
-    point GRAMPSHOME should have been set and the temporary Gramps
-    user directory structure created. The database will be imported
-    under there, and when testing is done the test fixture teardown
-    is responsible for cleanup.
+    Instantiation should occur during test fixture setup, which should
+    insure the temporary Gramps user directory structure was created.
+    The database will be imported under there, and when testing is done
+    the test fixture teardown is responsible for cleanup.
     """
 
     def __init__(self, name: str = None) -> None:
         """Prepare and import the example DB."""
-        importlib.reload(gramps.cli.clidbman)
-        from gramps.cli.clidbman import CLIDbManager
-
-        importlib.reload(gramps.cli.grampscli)
-        from gramps.cli.grampscli import CLIManager
-
         ExampleDbBase.__init__(self)
         self.db_path = os.path.join(os.environ["GRAMPSHOME"], "gramps", "grampsdb")
-        if not os.path.isdir(self.db_path):
-            os.makedirs(self.db_path)
+        os.makedirs(self.db_path, exist_ok=True)
         setconfig("database.path", self.db_path)
         dbstate = DbState()
         dbman = CLIDbManager(dbstate)

--- a/tests/test_endpoints/__init__.py
+++ b/tests/test_endpoints/__init__.py
@@ -16,8 +16,6 @@ from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EXAMPLE_GRAMPS_CONFIG
 
 from .. import TEST_GRAMPSHOME, ExampleDbSQLite
 
-global TEST_CLIENT, TEST_OBJECT_COUNTS
-
 
 def get_object_count(gramps_object):
     """Return count for an object type in database."""

--- a/tests/test_endpoints/__init__.py
+++ b/tests/test_endpoints/__init__.py
@@ -11,11 +11,12 @@ import yaml
 from pkg_resources import resource_filename
 
 import gramps_webapi.app
+from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EXAMPLE_GRAMPS_CONFIG
 
-from .. import ExampleDbSQLite
+from .. import TEST_GRAMPSHOME, ExampleDbSQLite
 
-global TEST_GRAMPSHOME, TEST_CLIENT, TEST_OBJECT_COUNTS
+global TEST_CLIENT, TEST_OBJECT_COUNTS
 
 
 def get_object_count(gramps_object):
@@ -30,18 +31,7 @@ def get_test_client():
 
 def setUpModule():
     """Test module setup."""
-    global TEST_GRAMPSHOME, TEST_CLIENT, TEST_OBJECT_COUNTS
-
-    TEST_GRAMPSHOME = tempfile.mkdtemp()
-    os.environ["GRAMPSHOME"] = TEST_GRAMPSHOME
-    importlib.reload(gramps.gen.const)
-    from gramps.gen.const import USER_DIRLIST
-
-    for path in USER_DIRLIST:
-        if not os.path.isdir(path):
-            os.makedirs(path)
-    importlib.reload(gramps_webapi.app)
-    from gramps_webapi.app import create_app
+    global TEST_CLIENT, TEST_OBJECT_COUNTS
 
     test_db = ExampleDbSQLite()
     with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_EXAMPLE_GRAMPS_CONFIG}):

--- a/tests/test_endpoints/test_filters.py
+++ b/tests/test_endpoints/test_filters.py
@@ -1,0 +1,43 @@
+"""Tests for the /api/filters endpoints using example_gramps."""
+
+import unittest
+
+from jsonschema import RefResolver, validate
+
+from gramps_webapi.const import GRAMPS_NAMESPACES
+
+from . import API_SCHEMA, get_test_client
+
+
+class TestFilters(unittest.TestCase):
+    """Test cases for the /api/filters/{namespace} endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_404(self):
+        """Test response for unsupported namespace."""
+        # check 404 returned for non-existent namespace
+        rv = self.client.get("/api/filters/nothing")
+        assert rv.status_code == 404
+
+    def test_filters_endpoint_schema(self):
+        """Test all namespaces against the filters schema."""
+        for namespace in GRAMPS_NAMESPACES:
+            rv = self.client.get("/api/filters/" + namespace)
+            # check no custom filters present yet
+            assert rv.json["filters"] == []
+            # check rules were returned
+            assert "rules" in rv.json
+            # check all rule records found conform to expected schema
+            resolver = RefResolver(
+                base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA}
+            )
+            for rule in rv.json["rules"]:
+                validate(
+                    instance=rule,
+                    schema=API_SCHEMA["definitions"]["FilterRuleDescription"],
+                    resolver=resolver,
+                )


### PR DESCRIPTION
@DavidMStraub I started on filter endpoint tests and immediately ran into an issue as it found the `custom_filters.xml` in my home `.gramps` directory. 

So I ended up having to refactor things again and set `GRAMPSHOME` in the top level `__init__.py` before any Gramps imports just as you had found when experimenting with `os.environ["LANGUAGE"] = "en"` before.  I think it is good actually, code is cleaner now. 

I would advise merging this right away.  I included the little I have for `test_filter.py` simply because it will fail if it finds a `custom_filters.xml` with filters defined, as it expects there to be none when it starts running, so it is good to have to confirm the test fixture setup should be as expected.