### PR TITLE
Add XML endpoint

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -22,6 +22,7 @@ from .resources.source import SourceResource, SourcesResource
 from .resources.tag import TagResource, TagsResource
 from .resources.token import TokenRefreshResource, TokenResource
 from .resources.translate import TranslationResource, TranslationsResource
+from .resources.xml import export_xml
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
 
@@ -74,9 +75,10 @@ register_endpt(TranslationResource, "/translations/<string:isocode>", "translati
 register_endpt(TranslationsResource, "/translations/", "translations")
 # Relation
 register_endpt(
-    RelationResource,
-    "/relations/<string:handle1>/<string:handle2>",
-    "relations",
+    RelationResource, "/relations/<string:handle1>/<string:handle2>", "relations",
 )
 # Metadata
 register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")
+
+# XML export
+api_blueprint.route("/xml")(export_xml)

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -81,4 +81,4 @@ register_endpt(
 register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")
 
 # XML export
-api_blueprint.route("/xml")(export_xml)
+api_blueprint.route("/export/xml")(export_xml)

--- a/gramps_webapi/api/resources/xml.py
+++ b/gramps_webapi/api/resources/xml.py
@@ -1,0 +1,44 @@
+"""Gramps XML export endpoint."""
+
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+
+from flask import send_file
+from gramps.cli.user import User
+from gramps.plugins.export.exportxml import XmlWriter
+from webargs import fields
+from webargs.flaskparser import use_args
+
+from ..util import get_dbstate
+from . import jwt_required_ifauth
+
+
+@jwt_required_ifauth
+@use_args({"compress": fields.Boolean(missing=False)}, location="query")
+def export_xml(args):
+    """Return the family tree as a Gramps XML file."""
+    dbstate = get_dbstate()
+    user = User()
+    writer = XmlWriter(
+        dbase=dbstate.db, user=user, strip_photos=0, compress=args["compress"]
+    )
+    # XmlWriter expects a filename as input, so we create a temp file.
+    # However, we don't want the temp file to stick around, so after
+    # writing it, we read it into memory and delete it; then we serve
+    # the buffer from memory.
+    f_xml = BytesIO()
+    with NamedTemporaryFile("rb") as f:
+        writer.write(f.name)
+        f.seek(0)
+        f_xml.write(f.read())
+        f_xml.seek(0)
+    if args["compress"]:
+        attachment_filename = "tree.gramps.gz"
+    else:
+        attachment_filename = "tree.gramps"
+    return send_file(
+        f_xml,
+        mimetype="application/xml",
+        as_attachment=True,
+        attachment_filename=attachment_filename,
+    )

--- a/tests/test_endpoints/test_xml.py
+++ b/tests/test_endpoints/test_xml.py
@@ -1,4 +1,4 @@
-"""Tests for the /api/xml endpoints using example_gramps."""
+"""Tests for the /api/export/xml endpoints using example_gramps."""
 
 import unittest
 
@@ -6,7 +6,7 @@ from . import get_test_client
 
 
 class TestXml(unittest.TestCase):
-    """Test cases for the /api/xml endpoint for a Gramps XML export."""
+    """Test cases for the /api/export/xml endpoint for a Gramps XML export."""
 
     @classmethod
     def setUpClass(cls):
@@ -15,10 +15,10 @@ class TestXml(unittest.TestCase):
 
     def test_xml_endpoint(self):
         """Test reponse for xml."""
-        rv = self.client.get("/api/xml/")
+        rv = self.client.get("/api/export/xml/")
         assert rv.mime == "application/xml"
 
     def test_xml_endpoint_compress(self):
         """Test reponse for xml with compress option."""
-        rv = self.client.get("/api/xml/?compress=1")
+        rv = self.client.get("/api/export/xml/?compress=1")
         assert rv.mime == "application/gz"

--- a/tests/test_endpoints/test_xml.py
+++ b/tests/test_endpoints/test_xml.py
@@ -1,0 +1,24 @@
+"""Tests for the /api/xml endpoints using example_gramps."""
+
+import unittest
+
+from . import get_test_client
+
+
+class TestXml(unittest.TestCase):
+    """Test cases for the /api/xml endpoint for a Gramps XML export."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_xml_endpoint(self):
+        """Test reponse for xml."""
+        rv = self.client.get("/api/xml/")
+        assert rv.mime == "application/xml"
+
+    def test_xml_endpoint_compress(self):
+        """Test reponse for xml with compress option."""
+        rv = self.client.get("/api/xml/?compress=1")
+        assert rv.mime == "application/gz"


### PR DESCRIPTION
This adds a simple `/api/xml` endpoint that returns the entire tree as a Gramps XML file download. With the option `?compress=1`, it returns the download in gzip format.

This can be used by apps to export the tree.

This can be improved in the future with the use of filters and by restricting private records, e.g. in combination with users groups (#15), but this PR is a start.