### PR TITLE
Filter endpoint tests, unittest asserts, pylint cleanups (Closes #45)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=10.0
+fail-under=10
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -589,6 +589,3 @@ valid-metaclass-classmethod-first-arg=cls
 # "BaseException, Exception".
 overgeneral-exceptions=BaseException,
                        Exception
-
-[MESSAGES CONTROL]
-disable = C0330, C0326

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -14,7 +14,7 @@ from .resources.bookmark import BookmarkResource, BookmarksResource
 from .resources.citation import CitationResource, CitationsResource
 from .resources.event import EventResource, EventsResource
 from .resources.family import FamiliesResource, FamilyResource
-from .resources.filters import FilterResource
+from .resources.filters import FilterResource, FiltersResource
 from .resources.media import MediaObjectResource, MediaObjectsResource
 from .resources.metadata import MetadataResource
 from .resources.name_groups import NameGroupsResource
@@ -81,7 +81,7 @@ register_endpt(BookmarkResource, "/bookmarks/<string:namespace>", "bookmark")
 register_endpt(BookmarksResource, "/bookmarks/", "bookmarks")
 # Filter
 register_endpt(FilterResource, "/filters/<string:namespace>/<string:name>", "filter")
-register_endpt(FilterResource, "/filters/<string:namespace>", "filters")
+register_endpt(FiltersResource, "/filters/<string:namespace>", "filters")
 # Translate
 register_endpt(TranslationResource, "/translations/<string:isocode>", "translation")
 register_endpt(TranslationsResource, "/translations/", "translations")

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -80,7 +80,8 @@ register_endpt(NameGroupsResource, "/name-groups/", "name-groups")
 register_endpt(BookmarkResource, "/bookmarks/<string:namespace>", "bookmark")
 register_endpt(BookmarksResource, "/bookmarks/", "bookmarks")
 # Filter
-register_endpt(FilterResource, "/filters/<string:namespace>", "filter")
+register_endpt(FilterResource, "/filters/<string:namespace>/<string:name>", "filter")
+register_endpt(FilterResource, "/filters/<string:namespace>", "filters")
 # Translate
 register_endpt(TranslationResource, "/translations/<string:isocode>", "translation")
 register_endpt(TranslationsResource, "/translations/", "translations")

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1909,10 +1909,38 @@ paths:
           description: "Forbidden: Bad credentials, authentication failed."
 
   /filters/{namespace}/{name}:    
+    get:
+      tags:
+      - filters
+      summary: "Get a custom filter for a given namespace or category."
+      operationId: getFilter
+      security:
+        - Bearer: []
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        type: string
+        description: "The namespace or category for the custom filter."
+      - name: name
+        in: path
+        required: true
+        type: string
+        description: "The name of a custom filter."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/CustomFilter"    
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Namespace or filter not found."
+
     delete:
       tags:
       - filters
-      summary: "Delete a custom filter."
+      summary: "Delete a custom filter in a given namespace or category."
       operationId: deleteFilter
       security:
         - Bearer: []

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1825,16 +1825,16 @@ paths:
         required: true
         type: string
         description: "The namespace or category for the filters."
-      - name: rule
+      - name: rules
         in: query
         required: false
         type: string
-        description: "The name of a specific filter rule to be returned."
-      - name: filter
+        description: "A comma delimited list of specific filter rules to be returned."
+      - name: filters
         in: query
         required: false
         type: string
-        description: "The name of a specific custom filter to be returned."
+        description: "A comma delimited list of specific custom filters to be returned."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1908,6 +1908,7 @@ paths:
         403:
           description: "Forbidden: Bad credentials, authentication failed."
 
+  /filters/{namespace}/{name}:    
     delete:
       tags:
       - filters
@@ -1921,12 +1922,16 @@ paths:
         required: true
         type: string
         description: "The namespace or category for the custom filter."
-      - name: filter
-        in: body
+      - name: name
+        in: path
         required: true
-        description: "The custom filter to delete."
-        schema:
-          $ref: "#/definitions/CustomFilterObject"    
+        type: string
+        description: "The name of the custom filter."
+      - name: force
+        in: query
+        required: false
+        type: string
+        description: "Force delete custom filter and all filters that depend upon it."
       responses:
         200:
           description: "OK: Successful operation."
@@ -4045,24 +4050,6 @@ definitions:
         items:
           $ref: "#/definitions/FilterRule"
 
-##############################################################################
-# Model - CustomFilterObject    
-##############################################################################
-
-  CustomFilterObject:
-    type: object
-    required:
-      - name
-    properties:
-      name:
-        type: string
-        description: "Name of the custom rule to delete."
-        example: "MyTestRule"
-      force:
-        type: boolean
-        description: "Indicator to approve deletion of all dependent filters if any exist."
-        example: true
-                         
 ##############################################################################
 # Model - Translations
 ##############################################################################

--- a/tests/test_endpoints/__init__.py
+++ b/tests/test_endpoints/__init__.py
@@ -13,8 +13,7 @@ from pkg_resources import resource_filename
 import gramps_webapi.app
 from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EXAMPLE_GRAMPS_CONFIG
-
-from .. import TEST_GRAMPSHOME, ExampleDbSQLite
+from tests import TEST_GRAMPSHOME, ExampleDbSQLite
 
 
 def get_object_count(gramps_object):

--- a/tests/test_endpoints/runners.py
+++ b/tests/test_endpoints/runners.py
@@ -248,14 +248,23 @@ def run_test_filters_endpoint_namespace(test, namespace: str, payload: Dict):
     # check response if filter already exists
     result = test.client.post("/api/filters/" + namespace, json=payload)
     test.assertEqual(result.status_code, 422)
-    # check can fetch the filter
+    # check can fetch the filter using query parm
     result = test.client.get("/api/filters/" + namespace + "?filters=" + filter_name)
     test.assertEqual(result.status_code, 200)
     test.assertTrue(len(result.json) == 1 and len(result.json["filters"]) == 1)
     test.assertEqual(result.json["filters"][0]["name"], filter_name)
-    # check response if fetching filter that does not exist
+    # check can fetch the filter using path
+    result = test.client.get("/api/filters/" + namespace + "/" + filter_name)
+    test.assertEqual(result.status_code, 200)
+    test.assertEqual(result.json["name"], filter_name)
+    # check response if fetching filter using query parm that does not exist
     result = test.client.get(
         "/api/filters/" + namespace + "?filters=" + filter_name + "Missing"
+    )
+    test.assertEqual(result.status_code, 404)
+    # check response if fetching filter using path that does not exist
+    result = test.client.get(
+        "/api/filters/" + namespace + "/" + filter_name + "Missing"
     )
     test.assertEqual(result.status_code, 404)
     # check response applying filter that does not exist

--- a/tests/test_endpoints/runners.py
+++ b/tests/test_endpoints/runners.py
@@ -3,110 +3,110 @@
 from typing import Dict, List, Optional
 
 
-def run_test_endpoint_gramps_id(client, endpoint: str, driver: Dict):
+def run_test_endpoint_gramps_id(test, endpoint: str, driver: Dict):
     """Test gramps_id parameter for a given endpoint."""
     # check 404 returned for non-existent object
-    rv = client.get(endpoint + "?gramps_id=does_not_exist")
-    assert rv.status_code == 404
+    result = test.client.get(endpoint + "?gramps_id=does_not_exist")
+    test.assertEqual(result.status_code, 404)
     # check only one record returned
-    rv = client.get(endpoint + "?gramps_id=" + driver["gramps_id"])
-    assert len(rv.json) == 1
+    result = test.client.get(endpoint + "?gramps_id=" + driver["gramps_id"])
+    test.assertEqual(len(result.json), 1)
     # check we have the expected record
     for key in driver:
-        assert rv.json[0][key] == driver[key]
+        test.assertEqual(result.json[0][key], driver[key])
 
 
-def run_test_endpoint_strip(client, endpoint: str):
+def run_test_endpoint_strip(test, endpoint: str):
     """Test strip parameter for a given endpoint."""
     # check 422 returned if passed argument
-    rv = client.get(endpoint + "?strip=1")
-    assert rv.status_code == 422
+    result = test.client.get(endpoint + "?strip=1")
+    test.assertEqual(result.status_code, 422)
     # check that keys for empty items are no longer in second object
-    bv = client.get(endpoint)
-    rv = client.get(endpoint + "?strip")
-    if isinstance(rv.json, List):
-        for item in bv.json:
-            check_keys_stripped(item, rv.json[bv.json.index(item)])
+    baseline = test.client.get(endpoint)
+    result = test.client.get(endpoint + "?strip")
+    if isinstance(result.json, type([])):
+        for item in baseline.json:
+            check_keys_stripped(test, item, result.json[baseline.json.index(item)])
     else:
-        check_keys_stripped(bv.json, rv.json)
+        check_keys_stripped(test, baseline.json, result.json)
 
 
-def check_keys_stripped(object1, object2):
+def check_keys_stripped(test, object1, object2):
     """Check keys for empty values in first object no longer exist in second."""
     for key in object1:
         if object1[key] in [[], {}, None]:
-            assert key not in object2
+            test.assertNotIn(key, object2)
         else:
-            if isinstance(object1[key], Dict):
-                check_keys_stripped(object1[key], object2[key])
-            if isinstance(object1[key], List):
+            if isinstance(object1[key], type({})):
+                check_keys_stripped(test, object1[key], object2[key])
+            if isinstance(object1[key], type([])):
                 for item in object1:
-                    if isinstance(item, List) or isinstance(item, Dict):
-                        check_keys_stripped(item, object2[object1.index(item)])
+                    if isinstance(item, (type([]), type({}))):
+                        check_keys_stripped(test, item, object2[object1.index(item)])
 
 
-def run_test_endpoint_keys(client, endpoint: str, keys: List[str]):
+def run_test_endpoint_keys(test, endpoint: str, keys: List[str]):
     """Test keys parameter for a given endpoint."""
     # check 422 returned if missing argument
-    rv = client.get(endpoint + "?keys")
-    assert rv.status_code == 422
+    result = test.client.get(endpoint + "?keys")
+    test.assertEqual(result.status_code, 422)
     # check results for the single key test that only key is present
     for key in keys:
-        rv = client.get(endpoint + "?keys=" + key)
-        if isinstance(rv.json, List):
-            for item in rv.json:
-                assert len(item) == 1
-                assert key in item
+        result = test.client.get(endpoint + "?keys=" + key)
+        if isinstance(result.json, type([])):
+            for item in result.json:
+                test.assertEqual(len(item), 1)
+                test.assertIn(key, item)
         else:
-            assert len(rv.json) == 1
-            assert key in rv.json
+            test.assertEqual(len(result.json), 1)
+            test.assertIn(key, result.json)
     # check results for the multi-key test that only keys are present
-    rv = client.get(endpoint + "?keys=" + ",".join(keys))
-    if isinstance(rv.json, List):
-        for item in rv.json:
-            assert len(item) == len(keys)
+    result = test.client.get(endpoint + "?keys=" + ",".join(keys))
+    if isinstance(result.json, type([])):
+        for item in result.json:
+            test.assertEqual(len(item), len(keys))
             for key in keys:
-                assert key in item
+                test.assertIn(key, item)
     else:
-        assert len(rv.json) == len(keys)
+        test.assertEqual(len(result.json), len(keys))
         for key in keys:
-            assert key in rv.json
+            test.assertIn(key, result.json)
 
 
-def run_test_endpoint_skipkeys(client, endpoint: str, keys: List[str]):
+def run_test_endpoint_skipkeys(test, endpoint: str, keys: List[str]):
     """Test skipkeys parameter for a given endpoint."""
     # check 422 returned if missing argument
-    rv = client.get(endpoint + "?skipkeys")
-    assert rv.status_code == 422
+    result = test.client.get(endpoint + "?skipkeys")
+    test.assertEqual(result.status_code, 422)
     # get total key count for tests
-    rv = client.get(endpoint)
-    if isinstance(rv.json, List):
-        key_count = len(rv.json[0])
+    result = test.client.get(endpoint)
+    if isinstance(result.json, type([])):
+        key_count = len(result.json[0])
     else:
-        key_count = len(rv.json)
+        key_count = len(result.json)
     # check results for the single key test that key was skipped
     size = key_count - 1
     for key in keys:
-        rv = client.get(endpoint + "?skipkeys=" + key)
-        if isinstance(rv.json, List):
-            for item in rv.json:
-                assert len(item) == size
-                assert key not in item
+        result = test.client.get(endpoint + "?skipkeys=" + key)
+        if isinstance(result.json, type([])):
+            for item in result.json:
+                test.assertEqual(len(item), size)
+                test.assertNotIn(key, item)
         else:
-            assert len(rv.json) == size
-            assert key not in rv.json
+            test.assertEqual(len(result.json), size)
+            test.assertNotIn(key, result.json)
     # check results for the multi-key test that keys were skipped
     size = key_count - len(keys)
-    rv = client.get(endpoint + "?skipkeys=" + ",".join(keys))
-    if isinstance(rv.json, List):
-        for item in rv.json:
-            assert len(item) == size
+    result = test.client.get(endpoint + "?skipkeys=" + ",".join(keys))
+    if isinstance(result.json, type([])):
+        for item in result.json:
+            test.assertEqual(len(item), size)
             for key in keys:
-                assert key not in item
+                test.assertNotIn(key, item)
     else:
-        assert len(rv.json) == size
+        test.assertEqual(len(result.json), size)
         for key in keys:
-            assert key not in rv.json
+            test.assertNotIn(key, result.json)
 
 
 # The driver must be a list with an entry for all possible extended fields for the
@@ -120,13 +120,16 @@ def run_test_endpoint_skipkeys(client, endpoint: str, keys: List[str]):
 
 
 def run_test_endpoint_extend(
-    client, endpoint: str, driver: List[Dict], driver_list: Optional[List[str]] = None
+    test,
+    endpoint: str,
+    driver: List[Dict],
+    driver_list: Optional[List[str]] = None,
 ):
     """Test extend parameter for a given endpoint."""
     driver_list = driver_list or []
     # check 422 returned if missing argument
-    rv = client.get(endpoint + "?extend")
-    assert rv.status_code == 422
+    result = test.client.get(endpoint + "?extend")
+    test.assertEqual(result.status_code, 422)
     # construct id list in event subset requested
     test_id_list = []
     expect_list = False
@@ -138,30 +141,38 @@ def run_test_endpoint_extend(
         test_id_list = [""]
     # check only the requested item is present in the result set
     for test_id in test_id_list:
-        for test in driver:
-            rv = client.get(endpoint + "?extend=" + test["arg"] + test_id)
+        for test_case in driver:
+            result = test.client.get(endpoint + "?extend=" + test_case["arg"] + test_id)
             if expect_list:
-                assert len(rv.json[0]["extended"]) == 1
-                assert isinstance(rv.json[0]["extended"][test["key"]], test["type"])
+                test.assertEqual(len(result.json[0]["extended"]), 1)
+                test.assertIsInstance(
+                    result.json[0]["extended"][test_case["key"]], test_case["type"]
+                )
             else:
-                assert len(rv.json["extended"]) == 1
-                assert isinstance(rv.json["extended"][test["key"]], test["type"])
+                test.assertEqual(len(result.json["extended"]), 1)
+                test.assertIsInstance(
+                    result.json["extended"][test_case["key"]], test_case["type"]
+                )
     # check all expected items are present in the result set
     for test_id in test_id_list:
-        rv = client.get(endpoint + "?extend=all" + test_id)
+        result = test.client.get(endpoint + "?extend=all" + test_id)
         if expect_list:
-            for item in rv.json:
-                assert len(item["extended"]) == len(driver)
-                for test in driver:
-                    assert isinstance(item["extended"][test["key"]], test["type"])
+            for item in result.json:
+                test.assertEqual(len(item["extended"]), len(driver))
+                for test_case in driver:
+                    test.assertIsInstance(
+                        item["extended"][test_case["key"]], test_case["type"]
+                    )
         else:
-            assert len(rv.json["extended"]) == len(driver)
-            for test in driver:
-                assert isinstance(rv.json["extended"][test["key"]], test["type"])
+            test.assertEqual(len(result.json["extended"]), len(driver))
+            for test_case in driver:
+                test.assertIsInstance(
+                    result.json["extended"][test_case["key"]], test_case["type"]
+                )
     # check multiple tags work as expected by using two together
     if len(driver_list) > 1:
         for test_id in test_id_list:
-            rv = client.get(
+            result = test.client.get(
                 endpoint
                 + "?extend="
                 + driver[0]["arg"]
@@ -170,40 +181,116 @@ def run_test_endpoint_extend(
                 + test_id
             )
             if expect_list:
-                assert len(rv.json[0]["extended"]) == 2
-                assert isinstance(
-                    rv.json[0]["extended"][driver[0]["key"]],
+                test.assertEqual(len(result.json[0]["extended"]), 2)
+                test.assertIsInstance(
+                    result.json[0]["extended"][driver[0]["key"]],
                     driver[0]["type"],
                 )
-                assert isinstance(
-                    rv.json[0]["extended"][driver[1]["key"]],
+                test.assertIsInstance(
+                    result.json[0]["extended"][driver[1]["key"]],
                     driver[1]["type"],
                 )
             else:
-                assert len(rv.json["extended"]) == 2
-                assert isinstance(
-                    rv.json["extended"][driver[0]["key"]], driver[0]["type"]
+                test.assertEqual(len(result.json["extended"]), 2)
+                test.assertIsInstance(
+                    result.json["extended"][driver[0]["key"]], driver[0]["type"]
                 )
-                assert isinstance(
-                    rv.json["extended"][driver[1]["key"]], driver[1]["type"]
+                test.assertIsInstance(
+                    result.json["extended"][driver[1]["key"]], driver[1]["type"]
                 )
 
 
-def run_test_endpoint_rules(client, endpoint: str, driver: Dict):
+def run_test_endpoint_rules(test, endpoint: str, driver: Dict):
     """Test rules parameter for a given endpoint."""
     # check 400 returned if passed improperly formatted argument
     for rules in driver[400]:
-        rv = client.get(endpoint + "?rules=" + rules)
-        assert rv.status_code == 400
+        result = test.client.get(endpoint + "?rules=" + rules)
+        test.assertEqual(result.status_code, 400)
     # check 422 returned if passed properly formatted argument with invalid schema
     for rules in driver[422]:
-        rv = client.get(endpoint + "?rules=" + rules)
-        assert rv.status_code == 422
+        result = test.client.get(endpoint + "?rules=" + rules)
+        test.assertEqual(result.status_code, 422)
     # check 404 returned if passed proper construct but with non-existent rule
     for rules in driver[404]:
-        rv = client.get(endpoint + "?rules=" + rules)
-        assert rv.status_code == 404
+        result = test.client.get(endpoint + "?rules=" + rules)
+        test.assertEqual(result.status_code, 404)
     # check 200 returned if rules filter constructed and executed properly
     for rules in driver[200]:
-        rv = client.get(endpoint + "?rules=" + rules)
-        assert rv.status_code == 200
+        result = test.client.get(endpoint + "?rules=" + rules)
+        test.assertEqual(result.status_code, 200)
+
+
+def run_test_filters_endpoint_namespace(test, namespace: str, payload: Dict):
+    """Test creation, application, update, and delete of a custom filter."""
+    # check 422 returned if missing rules parm argument
+    rule = payload["rules"][0]["name"]
+    result = test.client.get("/api/filters/" + namespace + "?rules")
+    test.assertEqual(result.status_code, 422)
+    # check 404 returned if rule does not exist
+    result = test.client.get("/api/filters/" + namespace + "?rules=IsSomeoneSomewhere")
+    test.assertEqual(result.status_code, 404)
+    # check single rule returned okay
+    result = test.client.get("/api/filters/" + namespace + "?rules=" + rule)
+    test.assertEqual(len(result.json["rules"]), 1)
+    test.assertEqual(result.json["rules"][0]["rule"], rule)
+    # check response for invalid create custom filter schema
+    payload["name"] = 123
+    result = test.client.post("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 422)
+    # check response for post to bad endpoint
+    filter_name = namespace.title() + "TestFilter"
+    payload["name"] = filter_name
+    result = test.client.post("/api/filters/junk", json=payload)
+    test.assertEqual(result.status_code, 404)
+    # check response for valid create
+    result = test.client.post("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 201)
+    # check response if filter already exists
+    result = test.client.post("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 422)
+    # check can fetch the filter
+    result = test.client.get("/api/filters/" + namespace + "?filters=" + filter_name)
+    test.assertEqual(result.status_code, 200)
+    test.assertTrue(len(result.json) == 1 and len(result.json["filters"]) == 1)
+    test.assertEqual(result.json["filters"][0]["name"], filter_name)
+    # check response if fetching filter that does not exist
+    result = test.client.get(
+        "/api/filters/" + namespace + "?filters=" + filter_name + "Missing"
+    )
+    test.assertEqual(result.status_code, 404)
+    # check response applying filter that does not exist
+    result = test.client.get(
+        "/api/" + namespace + "/?filter=" + filter_name + "Missing"
+    )
+    test.assertEqual(result.status_code, 404)
+    # check response applying the filter
+    result = test.client.get("/api/" + namespace + "/?filter=" + filter_name)
+    test.assertEqual(result.status_code, 200)
+    test.assertGreater(len(result.json), 0)
+    # check response for put to bad endpoint
+    result = test.client.put("/api/filters/" + namespace + "bad", json=payload)
+    test.assertEqual(result.status_code, 404)
+    # check response for update for filter that does not exist
+    payload["name"] = filter_name + "Missing"
+    result = test.client.put("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 404)
+    # check response for invalid update schema
+    payload["name"] = filter_name
+    payload["function"] = "junk"
+    result = test.client.put("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 422)
+    # check response for valid update
+    payload["function"] = "and"
+    payload["comment"] = "Update works"
+    result = test.client.put("/api/filters/" + namespace, json=payload)
+    test.assertEqual(result.status_code, 200)
+    # check filter was actually updated
+    result = test.client.get("/api/filters/" + namespace + "?filters=" + filter_name)
+    test.assertEqual(result.status_code, 200)
+    test.assertEqual(result.json["filters"][0]["comment"], "Update works")
+    # check delete success
+    result = test.client.delete("/api/filters/" + namespace + "/" + filter_name)
+    test.assertEqual(result.status_code, 200)
+    # check filter was actually deleted
+    result = test.client.get("/api/filters/" + namespace + "?filters=" + filter_name)
+    test.assertEqual(result.status_code, 404)

--- a/tests/test_endpoints/test_bookmarks.py
+++ b/tests/test_endpoints/test_bookmarks.py
@@ -4,7 +4,7 @@ import unittest
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_test_client
+from tests.test_endpoints import API_SCHEMA, get_test_client
 
 
 class TestBookmarks(unittest.TestCase):
@@ -18,32 +18,32 @@ class TestBookmarks(unittest.TestCase):
     def test_bookmarks_endpoint_schema(self):
         """Test bookmarks against the bookmark schema."""
         # check one response returned for namespace list
-        rv = self.client.get("/api/bookmarks/")
-        assert len(rv.json) == 1
+        result = self.client.get("/api/bookmarks/")
+        self.assertEqual(len(result.json), 1)
         # check record conforms to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["NameSpaces"],
             resolver=resolver,
         )
         # check one response returned for families
-        rv = self.client.get("/api/bookmarks/families")
-        assert len(rv.json) == 1
+        result = self.client.get("/api/bookmarks/families")
+        self.assertEqual(len(result.json), 1)
         # check record conforms to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Bookmarks"],
             resolver=resolver,
         )
         # check one response returned for people
-        rv = self.client.get("/api/bookmarks/people")
-        assert len(rv.json) == 1
+        result = self.client.get("/api/bookmarks/people")
+        self.assertEqual(len(result.json), 1)
         # check record conforms to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Bookmarks"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_citations.py
+++ b/tests/test_endpoints/test_citations.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestCitations(unittest.TestCase):
     def test_citations_endpoint(self):
         """Test reponse for citations."""
         # check expected number of citations found
-        rv = self.client.get("/api/citations/")
-        assert len(rv.json) == get_object_count("citations")
+        result = self.client.get("/api/citations/")
+        self.assertEqual(len(result.json), get_object_count("citations"))
         # check first record is expected citation
-        assert rv.json[0]["gramps_id"] == "C0000"
-        assert rv.json[0]["handle"] == "c140d2362f25a92643b"
-        assert rv.json[0]["source_handle"] == "b39fe3f390e30bd2b99"
+        self.assertEqual(result.json[0]["gramps_id"], "C0000")
+        self.assertEqual(result.json[0]["handle"], "c140d2362f25a92643b")
+        self.assertEqual(result.json[0]["source_handle"], "b39fe3f390e30bd2b99")
         # check last record is expected citation
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "C2853"
-        assert rv.json[last]["handle"] == "c140e0925ac0adcf8c4"
-        assert rv.json[last]["source_handle"] == "c140d4ef77841431905"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "C2853")
+        self.assertEqual(result.json[last]["handle"], "c140e0925ac0adcf8c4")
+        self.assertEqual(result.json[last]["source_handle"], "c140d4ef77841431905")
 
     def test_citations_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/citations/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/citations/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_citations_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,22 +52,22 @@ class TestCitations(unittest.TestCase):
             "handle": "c140dde678c5c4f4537",
             "source_handle": "c140d4ef77841431905",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/citations/", driver)
+        run_test_endpoint_gramps_id(self, "/api/citations/", driver)
 
     def test_citations_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/citations/")
+        run_test_endpoint_strip(self, "/api/citations/")
 
     def test_citations_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client, "/api/citations/", ["confidence", "handle", "page"]
+            self, "/api/citations/", ["confidence", "handle", "page"]
         )
 
     def test_citations_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/citations/", ["change", "media_list", "tag_list"]
+            self, "/api/citations/", ["change", "media_list", "tag_list"]
         )
 
     def test_citations_endpoint_rules(self):
@@ -81,14 +81,18 @@ class TestCitations(unittest.TestCase):
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasNote"}]}',
-                '{"rules":[{"name":"MatchesPageSubstringOf","values":["Page"]},{"name":"HasNote"}]}',
-                '{"function":"or","rules":[{"name":"MatchesPageSubstringOf","values":["Page"]},{"name":"HasNote"}]}',
-                '{"function":"xor","rules":[{"name":"MatchesPageSubstringOf","values":["Page"]},{"name":"HasNote"}]}',
-                '{"function":"one","rules":[{"name":"MatchesPageSubstringOf","values":["Page"]},{"name":"HasNote"}]}',
+                '{"rules":[{"name":"MatchesPageSubstringOf","values":["Page"]},'
+                + '{"name":"HasNote"}]}',
+                '{"function":"or","rules":[{"name":"MatchesPageSubstringOf",'
+                + '"values":["Page"]},{"name":"HasNote"}]}',
+                '{"function":"xor","rules":[{"name":"MatchesPageSubstringOf",'
+                + '"values":["Page"]},{"name":"HasNote"}]}',
+                '{"function":"one","rules":[{"name":"MatchesPageSubstringOf",'
+                + '"values":["Page"]},{"name":"HasNote"}]}',
                 '{"invert":true,"rules":[{"name":"HasNote"}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/citations/", driver)
+        run_test_endpoint_rules(self, "/api/citations/", driver)
 
     def test_citations_endpoint_extend(self):
         """Test response for extend parm."""
@@ -98,16 +102,16 @@ class TestCitations(unittest.TestCase):
             {"arg": "source_handle", "key": "source", "type": Dict},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/citations/", driver, ["C2849"])
+        run_test_endpoint_extend(self, "/api/citations/", driver, ["C2849"])
 
     def test_citations_endpoint_schema(self):
         """Test all citations against the citation schema."""
-        rv = self.client.get("/api/citations/?extend=all")
+        result = self.client.get("/api/citations/?extend=all")
         # check expected number of citations found
-        assert len(rv.json) == get_object_count("citations")
+        self.assertEqual(len(result.json), get_object_count("citations"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for citation in rv.json:
+        for citation in result.json:
             validate(
                 instance=citation,
                 schema=API_SCHEMA["definitions"]["Citation"],
@@ -126,30 +130,30 @@ class TestCitationsHandle(unittest.TestCase):
     def test_citations_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent citation
-        rv = self.client.get("/api/citations/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/citations/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_citations_handle_endpoint(self):
         """Test response for specific citation."""
         # check expected citation returned
-        rv = self.client.get("/api/citations/c140db880395cadf318")
-        assert rv.json["gramps_id"] == "C2844"
-        assert rv.json["source_handle"] == "c140d4ef77841431905"
+        result = self.client.get("/api/citations/c140db880395cadf318")
+        self.assertEqual(result.json["gramps_id"], "C2844")
+        self.assertEqual(result.json["source_handle"], "c140d4ef77841431905")
 
     def test_citations_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/citations/c140db880395cadf318?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/citations/c140db880395cadf318?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_citations_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/citations/c140db880395cadf318")
+        run_test_endpoint_strip(self, "/api/citations/c140db880395cadf318")
 
     def test_citations_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/citations/c140db880395cadf318",
             ["handle", "page", "private"],
         )
@@ -157,7 +161,7 @@ class TestCitationsHandle(unittest.TestCase):
     def test_citations_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/citations/c140db880395cadf318",
             ["handle", "media_list", "tag_list"],
         )
@@ -170,17 +174,15 @@ class TestCitationsHandle(unittest.TestCase):
             {"arg": "source_handle", "key": "source", "type": Dict},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(
-            self.client, "/api/citations/c140db880395cadf318", driver
-        )
+        run_test_endpoint_extend(self, "/api/citations/c140db880395cadf318", driver)
 
     def test_citations_handle_endpoint_schema(self):
         """Test the citation schema with extensions."""
         # check citation record conforms to expected schema
-        rv = self.client.get("/api/citations/c140db880395cadf318?extend=all")
+        result = self.client.get("/api/citations/c140db880395cadf318?extend=all")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Citation"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_events.py
+++ b/tests/test_endpoints/test_events.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,25 @@ class TestEvents(unittest.TestCase):
     def test_events_endpoint(self):
         """Test reponse for events."""
         # check expected number of events found
-        rv = self.client.get("/api/events/")
-        assert len(rv.json) == get_object_count("events")
+        result = self.client.get("/api/events/")
+        self.assertEqual(len(result.json), get_object_count("events"))
         # check first record is expected event
-        assert rv.json[0]["gramps_id"] == "E0000"
-        assert rv.json[0]["description"] == "Birth of Warner, Sarah Suzanne"
-        assert rv.json[0]["place"] == "08TJQCCFIX31BXPNXN"
+        self.assertEqual(result.json[0]["gramps_id"], "E0000")
+        self.assertEqual(
+            result.json[0]["description"], "Birth of Warner, Sarah Suzanne"
+        )
+        self.assertEqual(result.json[0]["place"], "08TJQCCFIX31BXPNXN")
         # check last record is expected event
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "E3431"
-        assert rv.json[last]["description"] == ""
-        assert rv.json[last]["place"] == ""
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "E3431")
+        self.assertEqual(result.json[last]["description"], "")
+        self.assertEqual(result.json[last]["place"], "")
 
     def test_events_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/events/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/events/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_events_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,22 +54,20 @@ class TestEvents(unittest.TestCase):
             "handle": "a5af0ebb51337f15e61",
             "place": "PH0KQCXU2AQ7P3TFHB",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/events/", driver)
+        run_test_endpoint_gramps_id(self, "/api/events/", driver)
 
     def test_events_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/events/")
+        run_test_endpoint_strip(self, "/api/events/")
 
     def test_events_endpoint_keys(self):
         """Test response for keys parm."""
-        run_test_endpoint_keys(
-            self.client, "/api/events/", ["handle", "description", "place"]
-        )
+        run_test_endpoint_keys(self, "/api/events/", ["handle", "description", "place"])
 
     def test_events_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/events/", ["change", "description", "tag_list"]
+            self, "/api/events/", ["change", "description", "tag_list"]
         )
 
     def test_events_endpoint_rules(self):
@@ -76,34 +76,41 @@ class TestEvents(unittest.TestCase):
             400: ['{"rules"[{"name":"HasType","values":["Marriage"]}]}'],
             422: [
                 '{"some":"where","rules":[{"name":"HasType","values":["Marriage"]}]}',
-                '{"function":"none","rules":[{"name":"HasType","values":["Marriage"]}]}',
+                '{"function":"none","rules":[{"name":"HasType",'
+                + '"values":["Marriage"]}]}',
             ],
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasType","values":["Marriage"]}]}',
                 '{"rules":[{"name":"HasType","values":["Death"]},{"name":"HasNote"}]}',
-                '{"function":"or","rules":[{"name":"HasType","values":["Death"]},{"name":"HasNote"}]}',
-                '{"function":"xor","rules":[{"name":"HasType","values":["Death"]},{"name":"HasNote"}]}',
-                '{"function":"one","rules":[{"name":"HasType","values":["Death"]},{"name":"HasNote"}]}',
+                '{"function":"or","rules":[{"name":"HasType","values":["Death"]},'
+                + '{"name":"HasNote"}]}',
+                '{"function":"xor","rules":[{"name":"HasType","values":["Death"]},'
+                + '{"name":"HasNote"}]}',
+                '{"function":"one","rules":[{"name":"HasType","values":["Death"]},'
+                + '{"name":"HasNote"}]}',
                 '{"invert":true,"rules":[{"name":"HasType","values":["Married"]}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/events/", driver)
+        run_test_endpoint_rules(self, "/api/events/", driver)
 
     def test_events_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/events/?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/events/?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check expected number of events found
-        rv = self.client.get("/api/events/?profile")
-        assert len(rv.json) == get_object_count("events")
+        result = self.client.get("/api/events/?profile")
+        self.assertEqual(len(result.json), get_object_count("events"))
         # check all expected profile attributes present for first event
-        assert rv.json[0]["profile"] == {
-            "date": "1987-08-29",
-            "place": "Gainesville, Llano, TX, USA",
-            "type": "Birth",
-        }
+        self.assertEqual(
+            result.json[0]["profile"],
+            {
+                "date": "1987-08-29",
+                "place": "Gainesville, Llano, TX, USA",
+                "type": "Birth",
+            },
+        )
 
     def test_events_endpoint_extend(self):
         """Test response for extend parm."""
@@ -114,16 +121,16 @@ class TestEvents(unittest.TestCase):
             {"arg": "place", "key": "place", "type": Dict},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/events/", driver, ["E0341"])
+        run_test_endpoint_extend(self, "/api/events/", driver, ["E0341"])
 
     def test_events_endpoint_schema(self):
         """Test all events against the event schema."""
-        rv = self.client.get("/api/events/?extend=all&profile")
+        result = self.client.get("/api/events/?extend=all&profile")
         # check expected number of events found
-        assert len(rv.json) == get_object_count("events")
+        self.assertEqual(len(result.json), get_object_count("events"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for event in rv.json:
+        for event in result.json:
             validate(
                 instance=event,
                 schema=API_SCHEMA["definitions"]["Event"],
@@ -142,30 +149,30 @@ class TestEventsHandle(unittest.TestCase):
     def test_events_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent event
-        rv = self.client.get("/api/events/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/events/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_events_handle_endpoint(self):
         """Test response for specific event."""
         # check expected event returned
-        rv = self.client.get("/api/events/a5af0eb6dd140de132c")
-        assert rv.json["gramps_id"] == "E0043"
-        assert rv.json["place"] == "P4EKQC5TG9HPIOXHN2"
+        result = self.client.get("/api/events/a5af0eb6dd140de132c")
+        self.assertEqual(result.json["gramps_id"], "E0043")
+        self.assertEqual(result.json["place"], "P4EKQC5TG9HPIOXHN2")
 
     def test_events_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/events/a5af0eb6dd140de132c?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/events/a5af0eb6dd140de132c?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_events_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/events/a5af0eb6dd140de132c")
+        run_test_endpoint_strip(self, "/api/events/a5af0eb6dd140de132c")
 
     def test_events_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/events/a5af0eb6dd140de132c",
             ["handle", "description", "type"],
         )
@@ -173,7 +180,7 @@ class TestEventsHandle(unittest.TestCase):
     def test_events_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/events/a5af0eb6dd140de132c",
             ["handle", "media_list", "private"],
         )
@@ -181,15 +188,18 @@ class TestEventsHandle(unittest.TestCase):
     def test_events_handle_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/events/a5af0eb6dd140de132c?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/events/a5af0eb6dd140de132c?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check some key expected profile attributes present
-        rv = self.client.get("/api/events/a5af0eb6dd140de132c?profile")
-        assert rv.json["profile"] == {
-            "date": "1250",
-            "place": "Atchison, Atchison, KS, USA",
-            "type": "Birth",
-        }
+        result = self.client.get("/api/events/a5af0eb6dd140de132c?profile")
+        self.assertEqual(
+            result.json["profile"],
+            {
+                "date": "1250",
+                "place": "Atchison, Atchison, KS, USA",
+                "type": "Birth",
+            },
+        )
 
     def test_events_handle_endpoint_extend(self):
         """Test response for extend parm."""
@@ -200,15 +210,15 @@ class TestEventsHandle(unittest.TestCase):
             {"arg": "place", "key": "place", "type": Dict},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/events/a5af0eb6dd140de132c", driver)
+        run_test_endpoint_extend(self, "/api/events/a5af0eb6dd140de132c", driver)
 
     def test_event_handle_endpoint_schema(self):
         """Test the event schema with extensions."""
         # check event record conforms to expected schema
-        rv = self.client.get("/api/events/a5af0eb6dd140de132c?extend=all&profile")
+        result = self.client.get("/api/events/a5af0eb6dd140de132c?extend=all&profile")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Event"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestFamilies(unittest.TestCase):
     def test_families_endpoint(self):
         """Test reponse for families."""
         # check expected number of families found
-        rv = self.client.get("/api/families/")
-        assert len(rv.json) == get_object_count("families")
+        result = self.client.get("/api/families/")
+        self.assertEqual(len(result.json), get_object_count("families"))
         # check first record is expected family
-        assert rv.json[0]["handle"] == "03GKQCH37C1SL9C5B3"
-        assert rv.json[0]["father_handle"] == "B2GKQCPG5WOVS9B4UL"
-        assert rv.json[0]["mother_handle"] == "83GKQCS0LVSVRX99KO"
+        self.assertEqual(result.json[0]["handle"], "03GKQCH37C1SL9C5B3")
+        self.assertEqual(result.json[0]["father_handle"], "B2GKQCPG5WOVS9B4UL")
+        self.assertEqual(result.json[0]["mother_handle"], "83GKQCS0LVSVRX99KO")
         # check last record is expected family
-        last = len(rv.json) - 1
-        assert rv.json[last]["handle"] == "d64cc45259c01f324b4"
-        assert rv.json[last]["father_handle"] == "d64cc45258f454e7dac"
-        assert rv.json[last]["mother_handle"] == "d64cc452655308a46f8"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["handle"], "d64cc45259c01f324b4")
+        self.assertEqual(result.json[last]["father_handle"], "d64cc45258f454e7dac")
+        self.assertEqual(result.json[last]["mother_handle"], "d64cc452655308a46f8")
 
     def test_families_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/families/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/families/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_families_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -53,22 +53,22 @@ class TestFamilies(unittest.TestCase):
             "father_handle": "9HUJQC6ONNW8SMSKGQ",
             "mother_handle": "EIUJQCVLRWQ1G8CS4",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/families/", driver)
+        run_test_endpoint_gramps_id(self, "/api/families/", driver)
 
     def test_families_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/families/")
+        run_test_endpoint_strip(self, "/api/families/")
 
     def test_families_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client, "/api/families/", ["handle", "child_ref_list", "media_list"]
+            self, "/api/families/", ["handle", "child_ref_list", "media_list"]
         )
 
     def test_families_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/families/", ["gramps_id", "lds_ord_list", "note_list"]
+            self, "/api/families/", ["gramps_id", "lds_ord_list", "note_list"]
         )
 
     def test_families_endpoint_rules(self):
@@ -82,83 +82,90 @@ class TestFamilies(unittest.TestCase):
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"IsBookmarked"}]}',
-                '{"rules":[{"name":"HasRelType","values":["Married"]},{"name":"IsBookmarked"}]}',
-                '{"function":"or","rules":[{"name":"HasRelType","values":["Unknown"]},{"name":"IsBookmarked"}]}',
-                '{"function":"xor","rules":[{"name":"HasRelType","values":["Unknown"]},{"name":"IsBookmarked"}]}',
-                '{"function":"one","rules":[{"name":"HasRelType","values":["Unknown"]},{"name":"IsBookmarked"}]}',
+                '{"rules":[{"name":"HasRelType","values":["Married"]},'
+                + '{"name":"IsBookmarked"}]}',
+                '{"function":"or","rules":[{"name":"HasRelType",'
+                + '"values":["Unknown"]},{"name":"IsBookmarked"}]}',
+                '{"function":"xor","rules":[{"name":"HasRelType",'
+                + '"values":["Unknown"]},{"name":"IsBookmarked"}]}',
+                '{"function":"one","rules":[{"name":"HasRelType",'
+                + '"values":["Unknown"]},{"name":"IsBookmarked"}]}',
                 '{"invert":true,"rules":[{"name":"HasRelType","values":["Married"]}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/families/", driver)
+        run_test_endpoint_rules(self, "/api/families/", driver)
 
     def test_families_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/families/?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/families/?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check expected number of families found
-        rv = self.client.get("/api/families/?profile")
-        assert len(rv.json) == get_object_count("families")
+        result = self.client.get("/api/families/?profile")
+        self.assertEqual(len(result.json), get_object_count("families"))
         # check all expected profile attributes present for first family
-        assert rv.json[0]["profile"] == {
-            "children": [
-                {
+        self.assertEqual(
+            result.json[0]["profile"],
+            {
+                "children": [
+                    {
+                        "birth": {
+                            "date": "",
+                            "place": "Gadsden, Etowah, AL, USA",
+                            "type": "Birth",
+                        },
+                        "death": {},
+                        "handle": "S3GKQCSAUG5LKNW2AK",
+                        "name_given": "Sarah",
+                        "name_surname": "Reed",
+                        "sex": "F",
+                    }
+                ],
+                "divorce": {},
+                "events": [
+                    {
+                        "date": "1879-07-25",
+                        "place": "Greensboro, NC, USA",
+                        "type": "Marriage",
+                    }
+                ],
+                "father": {
                     "birth": {
-                        "date": "",
-                        "place": "Gadsden, Etowah, AL, USA",
+                        "date": "1847-06-28",
+                        "place": "El Campo, Wharton, TX, USA",
                         "type": "Birth",
                     },
-                    "death": {},
-                    "handle": "S3GKQCSAUG5LKNW2AK",
-                    "name_given": "Sarah",
+                    "death": {
+                        "date": "1892-03-05",
+                        "place": "Plymouth, Marshall, IN, USA",
+                        "type": "Death",
+                    },
+                    "handle": "B2GKQCPG5WOVS9B4UL",
+                    "name_given": "Edward",
                     "name_surname": "Reed",
-                    "sex": "F",
-                }
-            ],
-            "divorce": {},
-            "events": [
-                {
+                    "sex": "M",
+                },
+                "handle": "03GKQCH37C1SL9C5B3",
+                "marriage": {
                     "date": "1879-07-25",
                     "place": "Greensboro, NC, USA",
                     "type": "Marriage",
-                }
-            ],
-            "father": {
-                "birth": {
-                    "date": "1847-06-28",
-                    "place": "El Campo, Wharton, TX, USA",
-                    "type": "Birth",
                 },
-                "death": {
-                    "date": "1892-03-05",
-                    "place": "Plymouth, Marshall, IN, USA",
-                    "type": "Death",
+                "mother": {
+                    "birth": {
+                        "date": "",
+                        "place": "Jacksonville, NC, USA",
+                        "type": "Birth",
+                    },
+                    "death": {},
+                    "handle": "83GKQCS0LVSVRX99KO",
+                    "name_given": "Ellen",
+                    "name_surname": "Reed",
+                    "sex": "F",
                 },
-                "handle": "B2GKQCPG5WOVS9B4UL",
-                "name_given": "Edward",
-                "name_surname": "Reed",
-                "sex": "M",
+                "relationship": "Married",
             },
-            "handle": "03GKQCH37C1SL9C5B3",
-            "marriage": {
-                "date": "1879-07-25",
-                "place": "Greensboro, NC, USA",
-                "type": "Marriage",
-            },
-            "mother": {
-                "birth": {
-                    "date": "",
-                    "place": "Jacksonville, NC, USA",
-                    "type": "Birth",
-                },
-                "death": {},
-                "handle": "83GKQCS0LVSVRX99KO",
-                "name_given": "Ellen",
-                "name_surname": "Reed",
-                "sex": "F",
-            },
-            "relationship": "Married",
-        }
+        )
 
     def test_families_endpoint_extend(self):
         """Test response for extend parm."""
@@ -172,16 +179,16 @@ class TestFamilies(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/families/", driver, ["F0045"])
+        run_test_endpoint_extend(self, "/api/families/", driver, ["F0045"])
 
     def test_families_endpoint_schema(self):
         """Test all families against the family schema."""
         # check expected number of families found
-        rv = self.client.get("/api/families/?extend=all&profile")
-        assert len(rv.json) == get_object_count("families")
+        result = self.client.get("/api/families/?extend=all&profile")
+        self.assertEqual(len(result.json), get_object_count("families"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for family in rv.json:
+        for family in result.json:
             validate(
                 instance=family,
                 schema=API_SCHEMA["definitions"]["Family"],
@@ -200,31 +207,31 @@ class TestFamiliesHandle(unittest.TestCase):
     def test_families_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent family
-        rv = self.client.get("/api/families/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/families/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_families_handle_endpoint(self):
         """Test response for a specific family."""
         # check expected family returned
-        rv = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB")
-        assert rv.json["gramps_id"] == "F0033"
-        assert rv.json["father_handle"] == "KLTJQC70XVZJSPQ43U"
-        assert rv.json["mother_handle"] == "JFWJQCRREDFKZLDKVD"
+        result = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB")
+        self.assertEqual(result.json["gramps_id"], "F0033")
+        self.assertEqual(result.json["father_handle"], "KLTJQC70XVZJSPQ43U")
+        self.assertEqual(result.json["mother_handle"], "JFWJQCRREDFKZLDKVD")
 
     def test_families_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_families_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/families/7MTJQCHRUUYSUA8ABB")
+        run_test_endpoint_strip(self, "/api/families/7MTJQCHRUUYSUA8ABB")
 
     def test_families_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/families/7MTJQCHRUUYSUA8ABB",
             ["gramps_id", "event_ref_list", "type"],
         )
@@ -232,7 +239,7 @@ class TestFamiliesHandle(unittest.TestCase):
     def test_families_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/families/7MTJQCHRUUYSUA8ABB",
             ["handle", "lds_ord_list", "child_ref_list"],
         )
@@ -240,73 +247,76 @@ class TestFamiliesHandle(unittest.TestCase):
     def test_families_handle_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check all expected profile attributes present
-        rv = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?profile")
-        assert rv.json["profile"] == {
-            "children": [
-                {
+        result = self.client.get("/api/families/7MTJQCHRUUYSUA8ABB?profile")
+        self.assertEqual(
+            result.json["profile"],
+            {
+                "children": [
+                    {
+                        "birth": {
+                            "date": "1983-10-05",
+                            "place": "Ottawa, La Salle, IL, USA",
+                            "type": "Birth",
+                        },
+                        "death": {},
+                        "handle": "1GWJQCGOOZ8FJW3YK9",
+                        "name_given": "Stephen Gerard",
+                        "name_surname": "Garner",
+                        "sex": "M",
+                    },
+                    {
+                        "birth": {
+                            "date": "1985-02-11",
+                            "place": "Ottawa, La Salle, IL, USA",
+                            "type": "Birth",
+                        },
+                        "death": {},
+                        "handle": "IGWJQCSVT8NXTFXOFJ",
+                        "name_given": "Daniel Patrick",
+                        "name_surname": "Garner",
+                        "sex": "M",
+                    },
+                ],
+                "divorce": {},
+                "events": [
+                    {
+                        "date": "1979-01-06",
+                        "place": "Farmington, MO, USA",
+                        "type": "Marriage",
+                    }
+                ],
+                "father": {
                     "birth": {
-                        "date": "1983-10-05",
+                        "date": "1955-07-31",
                         "place": "Ottawa, La Salle, IL, USA",
                         "type": "Birth",
                     },
                     "death": {},
-                    "handle": "1GWJQCGOOZ8FJW3YK9",
-                    "name_given": "Stephen Gerard",
+                    "handle": "KLTJQC70XVZJSPQ43U",
+                    "name_given": "Gerard Stephen",
                     "name_surname": "Garner",
                     "sex": "M",
                 },
-                {
-                    "birth": {
-                        "date": "1985-02-11",
-                        "place": "Ottawa, La Salle, IL, USA",
-                        "type": "Birth",
-                    },
-                    "death": {},
-                    "handle": "IGWJQCSVT8NXTFXOFJ",
-                    "name_given": "Daniel Patrick",
-                    "name_surname": "Garner",
-                    "sex": "M",
-                },
-            ],
-            "divorce": {},
-            "events": [
-                {
+                "handle": "7MTJQCHRUUYSUA8ABB",
+                "marriage": {
                     "date": "1979-01-06",
                     "place": "Farmington, MO, USA",
                     "type": "Marriage",
-                }
-            ],
-            "father": {
-                "birth": {
-                    "date": "1955-07-31",
-                    "place": "Ottawa, La Salle, IL, USA",
-                    "type": "Birth",
                 },
-                "death": {},
-                "handle": "KLTJQC70XVZJSPQ43U",
-                "name_given": "Gerard Stephen",
-                "name_surname": "Garner",
-                "sex": "M",
+                "mother": {
+                    "birth": {"date": "1957-01-31", "place": "", "type": "Birth"},
+                    "death": {},
+                    "handle": "JFWJQCRREDFKZLDKVD",
+                    "name_given": "Elizabeth",
+                    "name_surname": "George",
+                    "sex": "F",
+                },
+                "relationship": "Married",
             },
-            "handle": "7MTJQCHRUUYSUA8ABB",
-            "marriage": {
-                "date": "1979-01-06",
-                "place": "Farmington, MO, USA",
-                "type": "Marriage",
-            },
-            "mother": {
-                "birth": {"date": "1957-01-31", "place": "", "type": "Birth"},
-                "death": {},
-                "handle": "JFWJQCRREDFKZLDKVD",
-                "name_given": "Elizabeth",
-                "name_surname": "George",
-                "sex": "F",
-            },
-            "relationship": "Married",
-        }
+        )
 
     def test_families_handle_endpoint_extend(self):
         """Test response for extend parm."""
@@ -320,17 +330,15 @@ class TestFamiliesHandle(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(
-            self.client, "/api/families/7MTJQCHRUUYSUA8ABB", driver
-        )
+        run_test_endpoint_extend(self, "/api/families/7MTJQCHRUUYSUA8ABB", driver)
 
     def test_families_handle_endpoint_schema(self):
         """Test the family schema with extensions."""
         # check family record conforms to expected schema
-        rv = self.client.get("/api/families/1J4KQCRKU4410338P7?extend=all&profile")
+        result = self.client.get("/api/families/1J4KQCRKU4410338P7?extend=all&profile")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Family"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_filters.py
+++ b/tests/test_endpoints/test_filters.py
@@ -5,8 +5,8 @@ import unittest
 from jsonschema import RefResolver, validate
 
 from gramps_webapi.const import GRAMPS_NAMESPACES
-
-from . import API_SCHEMA, get_test_client
+from tests.test_endpoints import API_SCHEMA, get_test_client
+from tests.test_endpoints.runners import run_test_filters_endpoint_namespace
 
 
 class TestFilters(unittest.TestCase):
@@ -20,24 +20,195 @@ class TestFilters(unittest.TestCase):
     def test_filters_endpoint_404(self):
         """Test response for unsupported namespace."""
         # check 404 returned for non-existent namespace
-        rv = self.client.get("/api/filters/nothing")
-        assert rv.status_code == 404
+        result = self.client.get("/api/filters/nothing")
+        self.assertEqual(result.status_code, 404)
 
     def test_filters_endpoint_schema(self):
         """Test all namespaces against the filters schema."""
         for namespace in GRAMPS_NAMESPACES:
-            rv = self.client.get("/api/filters/" + namespace)
+            result = self.client.get("/api/filters/" + namespace)
             # check no custom filters present yet
-            assert rv.json["filters"] == []
+            self.assertEqual(result.json["filters"], [])
             # check rules were returned
-            assert "rules" in rv.json
+            self.assertIn("rules", result.json)
             # check all rule records found conform to expected schema
             resolver = RefResolver(
                 base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA}
             )
-            for rule in rv.json["rules"]:
+            for rule in result.json["rules"]:
                 validate(
                     instance=rule,
                     schema=API_SCHEMA["definitions"]["FilterRuleDescription"],
                     resolver=resolver,
                 )
+
+
+class TestFiltersPeople(unittest.TestCase):
+    """Test cases for the /api/filters/people endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_people_filter(self):
+        """Test creation and application of a people filter."""
+        payload = {
+            "comment": "Test person filter",
+            "name": 123,
+            "rules": [{"name": "IsMale"}, {"name": "MultipleMarriages"}],
+        }
+        run_test_filters_endpoint_namespace(self, "people", payload)
+
+
+class TestFiltersFamilies(unittest.TestCase):
+    """Test cases for the /api/filters/families endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_families_filter(self):
+        """Test creation and application of a families filter."""
+        payload = {
+            "comment": "Test family filter",
+            "name": 123,
+            "rules": [
+                {"name": "HasRelType", "values": ["Married"]},
+                {"name": "IsBookmarked"},
+            ],
+        }
+        run_test_filters_endpoint_namespace(self, "families", payload)
+
+
+class TestFiltersEvents(unittest.TestCase):
+    """Test cases for the /api/filters/events endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_events_filter(self):
+        """Test creation and application of an events filter."""
+        payload = {
+            "comment": "Test event filter",
+            "name": 123,
+            "rules": [{"name": "HasType", "values": ["Death"]}, {"name": "HasNote"}],
+        }
+        run_test_filters_endpoint_namespace(self, "events", payload)
+
+
+class TestFiltersPlaces(unittest.TestCase):
+    """Test cases for the /api/filters/places endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_places_filter(self):
+        """Test creation and application of a places filter."""
+        payload = {
+            "comment": "Test place filter",
+            "name": 123,
+            "rules": [{"name": "HasNoLatOrLon"}],
+        }
+        run_test_filters_endpoint_namespace(self, "places", payload)
+
+
+class TestFiltersCitations(unittest.TestCase):
+    """Test cases for the /api/filters/citations endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_citations_filter(self):
+        """Test creation and application of a citations filter."""
+        payload = {
+            "comment": "Test citation filter",
+            "name": 123,
+            "rules": [
+                {"name": "MatchesPageSubstringOf", "values": ["Page"]},
+                {"name": "HasNote"},
+            ],
+        }
+        run_test_filters_endpoint_namespace(self, "citations", payload)
+
+
+class TestFiltersSources(unittest.TestCase):
+    """Test cases for the /api/filters/sources endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_sources_filter(self):
+        """Test creation and application of a sources filter."""
+        payload = {
+            "comment": "Test source filter",
+            "name": 123,
+            "rules": [
+                {"name": "MatchesTitleSubstringOf", "values": ["Church"]},
+                {"name": "HasNote"},
+            ],
+        }
+        run_test_filters_endpoint_namespace(self, "sources", payload)
+
+
+class TestFiltersRepositories(unittest.TestCase):
+    """Test cases for the /api/filters/repositories endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_repositories_filter(self):
+        """Test creation and application of a repositories filter."""
+        payload = {
+            "comment": "Test repository filter",
+            "name": 123,
+            "rules": [{"name": "MatchesNameSubstringOf", "values": ["Library"]}],
+        }
+        run_test_filters_endpoint_namespace(self, "repositories", payload)
+
+
+class TestFiltersMedia(unittest.TestCase):
+    """Test cases for the /api/filters/media endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_media_filter(self):
+        """Test creation and application of a media filter."""
+        payload = {
+            "comment": "Test media filter",
+            "name": 123,
+            "rules": [{"name": "HasTag", "values": ["ToDo"]}],
+        }
+        run_test_filters_endpoint_namespace(self, "media", payload)
+
+
+class TestFiltersNotes(unittest.TestCase):
+    """Test cases for the /api/filters/notes endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_notes_filter(self):
+        """Test creation and application of a notes filter."""
+        payload = {
+            "comment": "Test notes filter",
+            "name": 123,
+            "rules": [{"name": "HasType", "values": ["Person Note"]}],
+        }
+        run_test_filters_endpoint_namespace(self, "notes", payload)

--- a/tests/test_endpoints/test_notes.py
+++ b/tests/test_endpoints/test_notes.py
@@ -5,8 +5,8 @@ from typing import List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestNotes(unittest.TestCase):
     def test_notes_endpoint(self):
         """Test reponse for notes."""
         # check expected number of notes found
-        rv = self.client.get("/api/notes/")
-        assert len(rv.json) == get_object_count("notes")
+        result = self.client.get("/api/notes/")
+        self.assertEqual(len(result.json), get_object_count("notes"))
         # check first record is expected note
-        assert rv.json[0]["gramps_id"] == "N0001"
-        assert rv.json[0]["handle"] == "ac380498bac48eedee8"
-        assert rv.json[0]["type"] == "Name Note"
+        self.assertEqual(result.json[0]["gramps_id"], "N0001")
+        self.assertEqual(result.json[0]["handle"], "ac380498bac48eedee8")
+        self.assertEqual(result.json[0]["type"], "Name Note")
         # check last record is expected note
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "_custom1"
-        assert rv.json[last]["handle"] == "d0436be64ac277b615b79b34e72"
-        assert rv.json[last]["type"] == "General"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "_custom1")
+        self.assertEqual(result.json[last]["handle"], "d0436be64ac277b615b79b34e72")
+        self.assertEqual(result.json[last]["type"], "General")
 
     def test_notes_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/notes/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/notes/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_notes_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,20 +52,20 @@ class TestNotes(unittest.TestCase):
             "handle": "d0436bba4ec328d3b631259a4ee",
             "type": "General",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/notes/", driver)
+        run_test_endpoint_gramps_id(self, "/api/notes/", driver)
 
     def test_notes_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/notes/")
+        run_test_endpoint_strip(self, "/api/notes/")
 
     def test_notes_endpoint_keys(self):
         """Test response for keys parm."""
-        run_test_endpoint_keys(self.client, "/api/notes/", ["handle", "text", "type"])
+        run_test_endpoint_keys(self, "/api/notes/", ["handle", "text", "type"])
 
     def test_notes_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/notes/", ["change", "format", "tag_list"]
+            self, "/api/notes/", ["change", "format", "tag_list"]
         )
 
     def test_notes_endpoint_rules(self):
@@ -73,36 +73,42 @@ class TestNotes(unittest.TestCase):
         driver = {
             400: ['{"rules"[{"name":"HasType","values":["Person Note"]}]}'],
             422: [
-                '{"some":"where","rules":[{"name":"HasType","values":["Person Note"]}]}',
-                '{"function":"none","rules":[{"name":"HasType","values":["Person Note"]}]}',
+                '{"some":"where","rules":[{"name":"HasType",'
+                + '"values":["Person Note"]}]}',
+                '{"function":"none","rules":[{"name":"HasType",'
+                + '"values":["Person Note"]}]}',
             ],
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasType","values":["Person Note"]}]}',
-                '{"rules":[{"name":"HasType","values":["Person Note"]},{"name":"NotePrivate"}]}',
-                '{"function":"or","rules":[{"name":"HasType","values":["Person Note"]},{"name":"NotePrivate"}]}',
-                '{"function":"xor","rules":[{"name":"HasType","values":["Person Note"]},{"name":"NotePrivate"}]}',
-                '{"function":"one","rules":[{"name":"HasType","values":["Person Note"]},{"name":"NotePrivate"}]}',
+                '{"rules":[{"name":"HasType","values":["Person Note"]},'
+                + '{"name":"NotePrivate"}]}',
+                '{"function":"or","rules":[{"name":"HasType",'
+                + '"values":["Person Note"]},{"name":"NotePrivate"}]}',
+                '{"function":"xor","rules":[{"name":"HasType",'
+                + '"values":["Person Note"]},{"name":"NotePrivate"}]}',
+                '{"function":"one","rules":[{"name":"HasType",'
+                + '"values":["Person Note"]},{"name":"NotePrivate"}]}',
                 '{"invert":true,"rules":[{"name":"HasType","values":["Person Note"]}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/notes/", driver)
+        run_test_endpoint_rules(self, "/api/notes/", driver)
 
     def test_notes_endpoint_extend(self):
         """Test response for extend parm."""
         driver = [
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/notes/", driver, ["N0003"])
+        run_test_endpoint_extend(self, "/api/notes/", driver, ["N0003"])
 
     def test_notes_endpoint_schema(self):
         """Test all notes against the note schema."""
-        rv = self.client.get("/api/notes/?extend=all")
+        result = self.client.get("/api/notes/?extend=all")
         # check expected number of notes found
-        assert len(rv.json) == get_object_count("notes")
+        self.assertEqual(len(result.json), get_object_count("notes"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for note in rv.json:
+        for note in result.json:
             validate(
                 instance=note,
                 schema=API_SCHEMA["definitions"]["Note"],
@@ -121,30 +127,30 @@ class TestNotesHandle(unittest.TestCase):
     def test_notes_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent note
-        rv = self.client.get("/api/notes/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/notes/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_notes_handle_endpoint(self):
         """Test response for specific note."""
         # check expected note returned
-        rv = self.client.get("/api/notes/ac3804aac6b762b75a5")
-        assert rv.json["gramps_id"] == "N0008"
-        assert rv.json["type"] == "Repository Note"
+        result = self.client.get("/api/notes/ac3804aac6b762b75a5")
+        self.assertEqual(result.json["gramps_id"], "N0008")
+        self.assertEqual(result.json["type"], "Repository Note")
 
     def test_notes_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/notes/ac3804aac6b762b75a5?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/notes/ac3804aac6b762b75a5?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_notes_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/notes/ac3804aac6b762b75a5")
+        run_test_endpoint_strip(self, "/api/notes/ac3804aac6b762b75a5")
 
     def test_notes_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/notes/ac3804aac6b762b75a5",
             ["handle", "text", "type"],
         )
@@ -152,7 +158,7 @@ class TestNotesHandle(unittest.TestCase):
     def test_notes_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/notes/ac3804aac6b762b75a5",
             ["change", "format", "private"],
         )
@@ -162,15 +168,15 @@ class TestNotesHandle(unittest.TestCase):
         driver = [
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/notes/ac3804aac6b762b75a5", driver)
+        run_test_endpoint_extend(self, "/api/notes/ac3804aac6b762b75a5", driver)
 
     def test_notes_handle_endpoint_schema(self):
         """Test the note schema with extensions."""
         # check note record conforms to expected schema
-        rv = self.client.get("/api/notes/ac3804aac6b762b75a5?extend=all")
+        result = self.client.get("/api/notes/ac3804aac6b762b75a5?extend=all")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Note"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,43 +27,47 @@ class TestPeople(unittest.TestCase):
     def test_people_endpoint(self):
         """Test reponse for people."""
         # check expected number of people found
-        rv = self.client.get("/api/people/")
-        assert len(rv.json) == get_object_count("people")
+        result = self.client.get("/api/people/")
+        self.assertEqual(len(result.json), get_object_count("people"))
         # check first record is expected person
-        assert rv.json[0]["gramps_id"] == "I0552"
-        assert rv.json[0]["primary_name"]["first_name"] == "Martha"
-        assert rv.json[0]["primary_name"]["surname_list"][0]["surname"] == "Nielsen"
+        self.assertEqual(result.json[0]["gramps_id"], "I0552")
+        self.assertEqual(result.json[0]["primary_name"]["first_name"], "Martha")
+        self.assertEqual(
+            result.json[0]["primary_name"]["surname_list"][0]["surname"], "Nielsen"
+        )
         # check last record is expected person
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "I2156"
-        assert rv.json[last]["primary_name"]["first_name"] == "蘭"
-        assert rv.json[last]["primary_name"]["surname_list"][0]["surname"] == "賈"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "I2156")
+        self.assertEqual(result.json[last]["primary_name"]["first_name"], "蘭")
+        self.assertEqual(
+            result.json[last]["primary_name"]["surname_list"][0]["surname"], "賈"
+        )
 
     def test_people_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/people/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/people/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_people_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
         driver = {"gramps_id": "I0044", "handle": "GNUJQCL9MD64AM56OH"}
-        run_test_endpoint_gramps_id(self.client, "/api/people/", driver)
+        run_test_endpoint_gramps_id(self, "/api/people/", driver)
 
     def test_people_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/people/")
+        run_test_endpoint_strip(self, "/api/people/")
 
     def test_people_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client, "/api/people/", ["handle", "primary_name", "event_ref_list"]
+            self, "/api/people/", ["handle", "primary_name", "event_ref_list"]
         )
 
     def test_people_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/people/", ["handle", "lds_ord_list", "person_ref_list"]
+            self, "/api/people/", ["handle", "lds_ord_list", "person_ref_list"]
         )
 
     def test_people_endpoint_rules(self):
@@ -78,81 +82,88 @@ class TestPeople(unittest.TestCase):
             200: [
                 '{"rules":[{"name":"HasUnknownGender"}]}',
                 '{"rules":[{"name":"IsMale"},{"name":"MultipleMarriages"}]}',
-                '{"function":"or","rules":[{"name":"HasTag","values":["complete"]},{"name":"HasTag","values":["ToDo"]}]}',
-                '{"function":"xor","rules":[{"name":"IsFemale"},{"name":"MultipleMarriages"}]}',
-                '{"function":"one","rules":[{"name":"IsFemale"},{"name":"MultipleMarriages"}]}',
-                '{"invert":true,"rules":[{"name":"IsMale"},{"name":"MultipleMarriages"}]}',
+                '{"function":"or","rules":[{"name":"HasTag",'
+                + '"values":["complete"]},{"name":"HasTag","values":["ToDo"]}]}',
+                '{"function":"xor","rules":[{"name":"IsFemale"},'
+                + '{"name":"MultipleMarriages"}]}',
+                '{"function":"one","rules":[{"name":"IsFemale"},'
+                + '{"name":"MultipleMarriages"}]}',
+                '{"invert":true,"rules":[{"name":"IsMale"},'
+                + '{"name":"MultipleMarriages"}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/people/", driver)
+        run_test_endpoint_rules(self, "/api/people/", driver)
 
     def test_people_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/people/?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/people/?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check expected number of people found
-        rv = self.client.get("/api/people/?profile")
-        assert len(rv.json) == get_object_count("people")
+        result = self.client.get("/api/people/?profile")
+        self.assertEqual(len(result.json), get_object_count("people"))
         # check all expected profile attributes present for first person
-        assert rv.json[0]["profile"] == {
-            "birth": {},
-            "death": {},
-            "events": [],
-            "families": [
-                {
-                    "children": [
-                        {
+        self.assertEqual(
+            result.json[0]["profile"],
+            {
+                "birth": {},
+                "death": {},
+                "events": [],
+                "families": [
+                    {
+                        "children": [
+                            {
+                                "birth": {
+                                    "date": "after 1737-10-01",
+                                    "place": "Maryville, MO, USA",
+                                    "type": "Birth",
+                                },
+                                "death": {
+                                    "date": "1787-05-20",
+                                    "place": "Wooster, OH, USA",
+                                    "type": "Death",
+                                },
+                                "handle": "E04KQC637O9JLP5PNM",
+                                "name_given": "John",
+                                "name_surname": "Adkins",
+                                "sex": "M",
+                            }
+                        ],
+                        "divorce": {},
+                        "events": [{"date": "", "place": "", "type": "Marriage"}],
+                        "father": {
                             "birth": {
-                                "date": "after 1737-10-01",
-                                "place": "Maryville, MO, USA",
+                                "date": "",
+                                "place": "Ketchikan, AK, USA",
                                 "type": "Birth",
                             },
-                            "death": {
-                                "date": "1787-05-20",
-                                "place": "Wooster, OH, USA",
-                                "type": "Death",
-                            },
-                            "handle": "E04KQC637O9JLP5PNM",
-                            "name_given": "John",
+                            "death": {},
+                            "handle": "JZ3KQCSRW7R368NLSH",
+                            "name_given": "Robert Sr.",
                             "name_surname": "Adkins",
                             "sex": "M",
-                        }
-                    ],
-                    "divorce": {},
-                    "events": [{"date": "", "place": "", "type": "Marriage"}],
-                    "father": {
-                        "birth": {
-                            "date": "",
-                            "place": "Ketchikan, AK, USA",
-                            "type": "Birth",
                         },
-                        "death": {},
-                        "handle": "JZ3KQCSRW7R368NLSH",
-                        "name_given": "Robert Sr.",
-                        "name_surname": "Adkins",
-                        "sex": "M",
-                    },
-                    "handle": "TZ3KQCJ3PNQHI6S8VO",
-                    "marriage": {"date": "", "place": "", "type": "Marriage"},
-                    "mother": {
-                        "birth": {},
-                        "death": {},
-                        "handle": "004KQCGYT27EEPQHK",
-                        "name_given": "Martha",
-                        "name_surname": "Nielsen",
-                        "sex": "F",
-                    },
-                    "relationship": "Married",
-                }
-            ],
-            "handle": "004KQCGYT27EEPQHK",
-            "name_given": "Martha",
-            "name_surname": "Nielsen",
-            "other_parent_families": [],
-            "primary_parent_family": {},
-            "sex": "F",
-        }
+                        "handle": "TZ3KQCJ3PNQHI6S8VO",
+                        "marriage": {"date": "", "place": "", "type": "Marriage"},
+                        "mother": {
+                            "birth": {},
+                            "death": {},
+                            "handle": "004KQCGYT27EEPQHK",
+                            "name_given": "Martha",
+                            "name_surname": "Nielsen",
+                            "sex": "F",
+                        },
+                        "relationship": "Married",
+                    }
+                ],
+                "handle": "004KQCGYT27EEPQHK",
+                "name_given": "Martha",
+                "name_surname": "Nielsen",
+                "other_parent_families": [],
+                "primary_parent_family": {},
+                "sex": "F",
+            },
+        )
 
     def test_people_endpoint_extend(self):
         """Test response for extend parm."""
@@ -171,16 +182,16 @@ class TestPeople(unittest.TestCase):
             },
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/people/", driver, ["I0044"])
+        run_test_endpoint_extend(self, "/api/people/", driver, ["I0044"])
 
     def test_people_endpoint_schema(self):
         """Test all people against the people schema."""
         # check expected number of people found
-        rv = self.client.get("/api/people/?extend=all&profile")
-        assert len(rv.json) == get_object_count("people")
+        result = self.client.get("/api/people/?extend=all&profile")
+        self.assertEqual(len(result.json), get_object_count("people"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for person in rv.json:
+        for person in result.json:
             validate(
                 instance=person,
                 schema=API_SCHEMA["definitions"]["Person"],
@@ -199,31 +210,33 @@ class TestPeopleHandle(unittest.TestCase):
     def test_people_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent person
-        rv = self.client.get("/api/people/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/people/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_people_handle_endpoint(self):
         """Test response for specific person."""
         # check expected person returned
-        rv = self.client.get("/api/people/GNUJQCL9MD64AM56OH")
-        assert rv.json["gramps_id"] == "I0044"
-        assert rv.json["primary_name"]["first_name"] == "Lewis Anderson"
-        assert rv.json["primary_name"]["surname_list"][1]["surname"] == "Zieliński"
+        result = self.client.get("/api/people/GNUJQCL9MD64AM56OH")
+        self.assertEqual(result.json["gramps_id"], "I0044")
+        self.assertEqual(result.json["primary_name"]["first_name"], "Lewis Anderson")
+        self.assertEqual(
+            result.json["primary_name"]["surname_list"][1]["surname"], "Zieliński"
+        )
 
     def test_people_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/people/GNUJQCL9MD64AM56OH?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/people/GNUJQCL9MD64AM56OH?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_people_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/people/1QTJQCP5QMT2X7YJDK")
+        run_test_endpoint_strip(self, "/api/people/1QTJQCP5QMT2X7YJDK")
 
     def test_people_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/people/1QTJQCP5QMT2X7YJDK",
             ["handle", "primary_name", "event_ref_list"],
         )
@@ -231,7 +244,7 @@ class TestPeopleHandle(unittest.TestCase):
     def test_people_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/people/1QTJQCP5QMT2X7YJDK",
             ["handle", "lds_ord_list", "person_ref_list"],
         )
@@ -239,136 +252,147 @@ class TestPeopleHandle(unittest.TestCase):
     def test_people_handle_endpoint_profile(self):
         """Test response for profile parm."""
         # check 422 returned if passed argument
-        rv = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?profile=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?profile=1")
+        self.assertEqual(result.status_code, 422)
         # check some key expected profile attributes present
-        rv = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?profile")
-        assert rv.json["profile"] == {
-            "birth": {
-                "date": "1906-09-05",
-                "place": "Central City, Muhlenberg, KY, USA",
-                "type": "Birth",
-            },
-            "death": {
-                "date": "1993-06-06",
-                "place": "Sevierville, TN, USA",
-                "type": "Death",
-            },
-            "events": [
-                {
+        result = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?profile")
+        self.assertEqual(
+            result.json["profile"],
+            {
+                "birth": {
                     "date": "1906-09-05",
                     "place": "Central City, Muhlenberg, KY, USA",
                     "type": "Birth",
                 },
-                {
+                "death": {
                     "date": "1993-06-06",
                     "place": "Sevierville, TN, USA",
                     "type": "Death",
                 },
-                {"date": "1993-06-08", "place": "Wenatchee, WA, USA", "type": "Burial"},
-            ],
-            "families": [],
-            "handle": "0PWJQCZYFXOS0HGREE",
-            "name_given": "Mary Grace Elizabeth",
-            "name_surname": "Warner",
-            "other_parent_families": [],
-            "primary_parent_family": {
-                "children": [
+                "events": [
                     {
+                        "date": "1906-09-05",
+                        "place": "Central City, Muhlenberg, KY, USA",
+                        "type": "Birth",
+                    },
+                    {
+                        "date": "1993-06-06",
+                        "place": "Sevierville, TN, USA",
+                        "type": "Death",
+                    },
+                    {
+                        "date": "1993-06-08",
+                        "place": "Wenatchee, WA, USA",
+                        "type": "Burial",
+                    },
+                ],
+                "families": [],
+                "handle": "0PWJQCZYFXOS0HGREE",
+                "name_given": "Mary Grace Elizabeth",
+                "name_surname": "Warner",
+                "other_parent_families": [],
+                "primary_parent_family": {
+                    "children": [
+                        {
+                            "birth": {
+                                "date": "1889-08-11",
+                                "place": "Panama City, Bay, FL, USA",
+                                "type": "Birth",
+                            },
+                            "death": {
+                                "date": "1961-08-12",
+                                "place": "Butte, MT, USA",
+                                "type": "Death",
+                            },
+                            "handle": "ENTJQCZXQV1IRKJXUL",
+                            "name_given": "Martin Bogarte",
+                            "name_surname": "Warner",
+                            "sex": "M",
+                        },
+                        {
+                            "birth": {
+                                "date": "1892-09-25",
+                                "place": "New Castle, Henry, IN, USA",
+                                "type": "Birth",
+                            },
+                            "death": {
+                                "date": "1970-12-17",
+                                "place": "",
+                                "type": "Death",
+                            },
+                            "handle": "4OWJQC0KHBI9AR3QX3",
+                            "name_given": "Julia Angeline",
+                            "name_surname": "Warner",
+                            "sex": "F",
+                        },
+                        {
+                            "birth": {
+                                "date": "1906-09-05",
+                                "place": "Central City, Muhlenberg, KY, USA",
+                                "type": "Birth",
+                            },
+                            "death": {
+                                "date": "1993-06-06",
+                                "place": "Sevierville, TN, USA",
+                                "type": "Death",
+                            },
+                            "handle": "0PWJQCZYFXOS0HGREE",
+                            "name_given": "Mary Grace Elizabeth",
+                            "name_surname": "Warner",
+                            "sex": "F",
+                        },
+                    ],
+                    "divorce": {},
+                    "events": [
+                        {
+                            "date": "1888-08-09",
+                            "place": "Springfield, Sangamon, IL, USA",
+                            "type": "Marriage",
+                        }
+                    ],
+                    "father": {
                         "birth": {
-                            "date": "1889-08-11",
-                            "place": "Panama City, Bay, FL, USA",
+                            "date": "1867-01-23",
+                            "place": "Durango, La Plata, CO, USA",
                             "type": "Birth",
                         },
                         "death": {
-                            "date": "1961-08-12",
-                            "place": "Butte, MT, USA",
+                            "date": "1919-03-10",
+                            "place": "Kokomo, Howard, IN, USA",
                             "type": "Death",
                         },
-                        "handle": "ENTJQCZXQV1IRKJXUL",
-                        "name_given": "Martin Bogarte",
+                        "handle": "SOTJQCKJPETYI38BRM",
+                        "name_given": "Warren W.",
                         "name_surname": "Warner",
                         "sex": "M",
                     },
-                    {
-                        "birth": {
-                            "date": "1892-09-25",
-                            "place": "New Castle, Henry, IN, USA",
-                            "type": "Birth",
-                        },
-                        "death": {"date": "1970-12-17", "place": "", "type": "Death"},
-                        "handle": "4OWJQC0KHBI9AR3QX3",
-                        "name_given": "Julia Angeline",
-                        "name_surname": "Warner",
-                        "sex": "F",
-                    },
-                    {
-                        "birth": {
-                            "date": "1906-09-05",
-                            "place": "Central City, Muhlenberg, KY, USA",
-                            "type": "Birth",
-                        },
-                        "death": {
-                            "date": "1993-06-06",
-                            "place": "Sevierville, TN, USA",
-                            "type": "Death",
-                        },
-                        "handle": "0PWJQCZYFXOS0HGREE",
-                        "name_given": "Mary Grace Elizabeth",
-                        "name_surname": "Warner",
-                        "sex": "F",
-                    },
-                ],
-                "divorce": {},
-                "events": [
-                    {
+                    "handle": "LOTJQC78O5B4WQGJRP",
+                    "marriage": {
                         "date": "1888-08-09",
                         "place": "Springfield, Sangamon, IL, USA",
                         "type": "Marriage",
-                    }
-                ],
-                "father": {
-                    "birth": {
-                        "date": "1867-01-23",
-                        "place": "Durango, La Plata, CO, USA",
-                        "type": "Birth",
                     },
-                    "death": {
-                        "date": "1919-03-10",
-                        "place": "Kokomo, Howard, IN, USA",
-                        "type": "Death",
+                    "mother": {
+                        "birth": {
+                            "date": "1869-07-08",
+                            "place": "Oxnard, Ventura, CA, USA",
+                            "type": "Birth",
+                        },
+                        "death": {
+                            "date": "1942-04-21",
+                            "place": "Kokomo, Howard, IN, USA",
+                            "type": "Death",
+                        },
+                        "handle": "1QTJQCP5QMT2X7YJDK",
+                        "name_given": "Abigail",
+                        "name_surname": "Ball",
+                        "sex": "F",
                     },
-                    "handle": "SOTJQCKJPETYI38BRM",
-                    "name_given": "Warren W.",
-                    "name_surname": "Warner",
-                    "sex": "M",
+                    "relationship": "Married",
                 },
-                "handle": "LOTJQC78O5B4WQGJRP",
-                "marriage": {
-                    "date": "1888-08-09",
-                    "place": "Springfield, Sangamon, IL, USA",
-                    "type": "Marriage",
-                },
-                "mother": {
-                    "birth": {
-                        "date": "1869-07-08",
-                        "place": "Oxnard, Ventura, CA, USA",
-                        "type": "Birth",
-                    },
-                    "death": {
-                        "date": "1942-04-21",
-                        "place": "Kokomo, Howard, IN, USA",
-                        "type": "Death",
-                    },
-                    "handle": "1QTJQCP5QMT2X7YJDK",
-                    "name_given": "Abigail",
-                    "name_surname": "Ball",
-                    "sex": "F",
-                },
-                "relationship": "Married",
+                "sex": "F",
             },
-            "sex": "F",
-        }
+        )
 
     def test_people_handle_endpoint_extend(self):
         """Test response for extend parm."""
@@ -387,15 +411,15 @@ class TestPeopleHandle(unittest.TestCase):
             },
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/people/0PWJQCZYFXOS0HGREE", driver)
+        run_test_endpoint_extend(self, "/api/people/0PWJQCZYFXOS0HGREE", driver)
 
     def test_people_handle_endpoint_schema(self):
         """Test the people schema with extensions."""
         # check person record conforms to expected schema
-        rv = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?extend=all&profile")
+        result = self.client.get("/api/people/0PWJQCZYFXOS0HGREE?extend=all&profile")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Person"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_places.py
+++ b/tests/test_endpoints/test_places.py
@@ -5,8 +5,8 @@ from typing import List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestPlaces(unittest.TestCase):
     def test_places_endpoint(self):
         """Test reponse for places."""
         # check expected number of places found
-        rv = self.client.get("/api/places/")
-        assert len(rv.json) == get_object_count("places")
+        result = self.client.get("/api/places/")
+        self.assertEqual(len(result.json), get_object_count("places"))
         # check first record is expected place
-        assert rv.json[0]["gramps_id"] == "P0852"
-        assert rv.json[0]["handle"] == "00BKQC7SA8C9NCGB0A"
-        assert rv.json[0]["title"] == "Deltona, FL"
+        self.assertEqual(result.json[0]["gramps_id"], "P0852")
+        self.assertEqual(result.json[0]["handle"], "00BKQC7SA8C9NCGB0A")
+        self.assertEqual(result.json[0]["title"], "Deltona, FL")
         # check last record is expected place
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "P0441"
-        assert rv.json[last]["handle"] == "dd445e5bfcc17bd1838"
-        assert rv.json[last]["title"] == ""
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "P0441")
+        self.assertEqual(result.json[last]["handle"], "dd445e5bfcc17bd1838")
+        self.assertEqual(result.json[last]["title"], "")
 
     def test_places_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/places/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/places/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_places_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,22 +52,20 @@ class TestPlaces(unittest.TestCase):
             "handle": "B9VKQCD14KD2OH3QZY",
             "title": "York, PA",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/places/", driver)
+        run_test_endpoint_gramps_id(self, "/api/places/", driver)
 
     def test_places_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/places/")
+        run_test_endpoint_strip(self, "/api/places/")
 
     def test_places_endpoint_keys(self):
         """Test response for keys parm."""
-        run_test_endpoint_keys(
-            self.client, "/api/places/", ["handle", "place_type", "title"]
-        )
+        run_test_endpoint_keys(self, "/api/places/", ["handle", "place_type", "title"])
 
     def test_places_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/places/", ["alt_loc", "code", "placeref_list"]
+            self, "/api/places/", ["alt_loc", "code", "placeref_list"]
         )
 
     def test_places_endpoint_rules(self):
@@ -81,14 +79,18 @@ class TestPlaces(unittest.TestCase):
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasNoLatOrLon"}]}',
-                '{"rules":[{"name":"HasNoLatOrLon"},{"name":"HasTag","values":["None"]}]}',
-                '{"function":"or","rules":[{"name":"HasNoLatOrLon"},{"name":"HasTag","values":["None"]}]}',
-                '{"function":"xor","rules":[{"name":"HasNoLatOrLon"},{"name":"HasTag","values":["None"]}]}',
-                '{"function":"one","rules":[{"name":"HasNoLatOrLon"},{"name":"HasTag","values":["None"]}]}',
+                '{"rules":[{"name":"HasNoLatOrLon"},'
+                + '{"name":"HasTag","values":["None"]}]}',
+                '{"function":"or","rules":[{"name":"HasNoLatOrLon"},'
+                + '{"name":"HasTag","values":["None"]}]}',
+                '{"function":"xor","rules":[{"name":"HasNoLatOrLon"},'
+                + '{"name":"HasTag","values":["None"]}]}',
+                '{"function":"one","rules":[{"name":"HasNoLatOrLon"},'
+                + '{"name":"HasTag","values":["None"]}]}',
                 '{"invert":true,"rules":[{"name":"HasNoLatOrLon"}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/places/", driver)
+        run_test_endpoint_rules(self, "/api/places/", driver)
 
     def test_places_endpoint_extend(self):
         """Test response for extend parm."""
@@ -98,16 +100,16 @@ class TestPlaces(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/places/", driver, ["P1108"])
+        run_test_endpoint_extend(self, "/api/places/", driver, ["P1108"])
 
     def test_places_endpoint_schema(self):
         """Test all places against the place schema."""
-        rv = self.client.get("/api/places/?extend=all")
+        result = self.client.get("/api/places/?extend=all")
         # check expected number of places found
-        assert len(rv.json) == get_object_count("places")
+        self.assertEqual(len(result.json), get_object_count("places"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for place in rv.json:
+        for place in result.json:
             validate(
                 instance=place,
                 schema=API_SCHEMA["definitions"]["Place"],
@@ -126,30 +128,30 @@ class TestPlacesHandle(unittest.TestCase):
     def test_places_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent place
-        rv = self.client.get("/api/places/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/places/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_places_handle_endpoint(self):
         """Test response for specific place."""
         # check expected place returned
-        rv = self.client.get("/api/places/09UJQCF3TNGH9GU0P1")
-        assert rv.json["gramps_id"] == "P0863"
-        assert rv.json["title"] == "Bowling Green, KY"
+        result = self.client.get("/api/places/09UJQCF3TNGH9GU0P1")
+        self.assertEqual(result.json["gramps_id"], "P0863")
+        self.assertEqual(result.json["title"], "Bowling Green, KY")
 
     def test_places_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/places/09UJQCF3TNGH9GU0P1?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/places/09UJQCF3TNGH9GU0P1?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_places_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/places/09UJQCF3TNGH9GU0P1")
+        run_test_endpoint_strip(self, "/api/places/09UJQCF3TNGH9GU0P1")
 
     def test_places_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/places/09UJQCF3TNGH9GU0P1",
             ["handle", "lat", "long"],
         )
@@ -157,7 +159,7 @@ class TestPlacesHandle(unittest.TestCase):
     def test_places_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/places/09UJQCF3TNGH9GU0P1",
             ["handle", "media_list", "private"],
         )
@@ -170,15 +172,15 @@ class TestPlacesHandle(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/places/09UJQCF3TNGH9GU0P1", driver)
+        run_test_endpoint_extend(self, "/api/places/09UJQCF3TNGH9GU0P1", driver)
 
     def test_places_handle_endpoint_schema(self):
         """Test the place schema with extensions."""
         # check place record conforms to expected schema
-        rv = self.client.get("/api/places/09UJQCF3TNGH9GU0P1?extend=all")
+        result = self.client.get("/api/places/09UJQCF3TNGH9GU0P1?extend=all")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Place"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_repositories.py
+++ b/tests/test_endpoints/test_repositories.py
@@ -5,8 +5,8 @@ from typing import List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestRepositories(unittest.TestCase):
     def test_repositories_endpoint(self):
         """Test reponse for repositories."""
         # check expected number of repositories found
-        rv = self.client.get("/api/repositories/")
-        assert len(rv.json) == get_object_count("repositories")
+        result = self.client.get("/api/repositories/")
+        self.assertEqual(len(result.json), get_object_count("repositories"))
         # check first record is expected repository
-        assert rv.json[0]["gramps_id"] == "R0002"
-        assert rv.json[0]["handle"] == "a701e99f93e5434f6f3"
-        assert rv.json[0]["type"] == "Library"
+        self.assertEqual(result.json[0]["gramps_id"], "R0002")
+        self.assertEqual(result.json[0]["handle"], "a701e99f93e5434f6f3")
+        self.assertEqual(result.json[0]["type"], "Library")
         # check last record is expected repository
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "R0000"
-        assert rv.json[last]["handle"] == "b39fe38593f3f8c4f12"
-        assert rv.json[last]["type"] == "Library"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "R0000")
+        self.assertEqual(result.json[last]["handle"], "b39fe38593f3f8c4f12")
+        self.assertEqual(result.json[last]["type"], "Library")
 
     def test_repositories_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/repositories/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/repositories/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_repositories_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,22 +52,22 @@ class TestRepositories(unittest.TestCase):
             "handle": "a701ead12841521cd4d",
             "type": "Collection",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/repositories/", driver)
+        run_test_endpoint_gramps_id(self, "/api/repositories/", driver)
 
     def test_repositories_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/repositories/")
+        run_test_endpoint_strip(self, "/api/repositories/")
 
     def test_repositories_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client, "/api/repositories/", ["address_list", "note_list", "urls"]
+            self, "/api/repositories/", ["address_list", "note_list", "urls"]
         )
 
     def test_repositories_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/repositories/", ["change", "private", "tag_list"]
+            self, "/api/repositories/", ["change", "private", "tag_list"]
         )
 
     def test_repositories_endpoint_rules(self):
@@ -81,14 +81,18 @@ class TestRepositories(unittest.TestCase):
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasTag","values":["ToDo"]}]}',
-                '{"rules":[{"name":"MatchesNameSubstringOf","values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
-                '{"function":"or","rules":[{"name":"MatchesNameSubstringOf","values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
-                '{"function":"xor","rules":[{"name":"MatchesNameSubstringOf","values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
-                '{"function":"one","rules":[{"name":"MatchesNameSubstringOf","values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
+                '{"rules":[{"name":"MatchesNameSubstringOf",'
+                + '"values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
+                '{"function":"or","rules":[{"name":"MatchesNameSubstringOf",'
+                + '"values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
+                '{"function":"xor","rules":[{"name":"MatchesNameSubstringOf",'
+                + '"values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
+                '{"function":"one","rules":[{"name":"MatchesNameSubstringOf",'
+                + '"values":["Library"]},{"name":"HasTag","values":["ToDo"]}]}',
                 '{"invert":true,"rules":[{"name":"HasTag","values":["ToDo"]}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/repositories/", driver)
+        run_test_endpoint_rules(self, "/api/repositories/", driver)
 
     def test_repositories_endpoint_extend(self):
         """Test response for extend parm."""
@@ -96,16 +100,16 @@ class TestRepositories(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/repositories/", driver, ["R0003"])
+        run_test_endpoint_extend(self, "/api/repositories/", driver, ["R0003"])
 
     def test_repositories_endpoint_schema(self):
         """Test all repositories against the repository schema."""
-        rv = self.client.get("/api/repositories/?extend=all")
+        result = self.client.get("/api/repositories/?extend=all")
         # check expected number of repositories found
-        assert len(rv.json) == get_object_count("repositories")
+        self.assertEqual(len(result.json), get_object_count("repositories"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for repository in rv.json:
+        for repository in result.json:
             validate(
                 instance=repository,
                 schema=API_SCHEMA["definitions"]["Repository"],
@@ -114,7 +118,7 @@ class TestRepositories(unittest.TestCase):
 
 
 class TestRepositoriesHandle(unittest.TestCase):
-    """Test cases for the /api/repositories/{handle} endpoint for a specific repository."""
+    """Test cases for the /api/repositories/{handle} endpoint for a repository."""
 
     @classmethod
     def setUpClass(cls):
@@ -124,30 +128,30 @@ class TestRepositoriesHandle(unittest.TestCase):
     def test_repositories_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent repositorie
-        rv = self.client.get("/api/repositories/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/repositories/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_repositories_handle_endpoint(self):
         """Test response for specific repository."""
         # check expected repository returned
-        rv = self.client.get("/api/repositories/b39fe38593f3f8c4f12")
-        assert rv.json["gramps_id"] == "R0000"
-        assert rv.json["type"] == "Library"
+        result = self.client.get("/api/repositories/b39fe38593f3f8c4f12")
+        self.assertEqual(result.json["gramps_id"], "R0000")
+        self.assertEqual(result.json["type"], "Library")
 
     def test_repositories_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/repositories/b39fe38593f3f8c4f12?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/repositories/b39fe38593f3f8c4f12?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_repositories_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/repositories/b39fe38593f3f8c4f12")
+        run_test_endpoint_strip(self, "/api/repositories/b39fe38593f3f8c4f12")
 
     def test_repositories_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/repositories/b39fe38593f3f8c4f12",
             ["handle", "name", "type"],
         )
@@ -155,7 +159,7 @@ class TestRepositoriesHandle(unittest.TestCase):
     def test_repositories_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/repositories/b39fe38593f3f8c4f12",
             ["handle", "note_list", "change"],
         )
@@ -166,17 +170,15 @@ class TestRepositoriesHandle(unittest.TestCase):
             {"arg": "note_list", "key": "notes", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(
-            self.client, "/api/repositories/b39fe38593f3f8c4f12", driver
-        )
+        run_test_endpoint_extend(self, "/api/repositories/b39fe38593f3f8c4f12", driver)
 
     def test_repositories_handle_endpoint_schema(self):
         """Test the repository schema with extensions."""
         # check repository record conforms to expected schema
-        rv = self.client.get("/api/repositories/b39fe38593f3f8c4f12?extend=all")
+        result = self.client.get("/api/repositories/b39fe38593f3f8c4f12?extend=all")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Repository"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_sources.py
+++ b/tests/test_endpoints/test_sources.py
@@ -5,8 +5,8 @@ from typing import List
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
-from .runners import (
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints.runners import (
     run_test_endpoint_extend,
     run_test_endpoint_gramps_id,
     run_test_endpoint_keys,
@@ -27,23 +27,23 @@ class TestSources(unittest.TestCase):
     def test_sources_endpoint(self):
         """Test reponse for sources."""
         # check expected number of sources found
-        rv = self.client.get("/api/sources/")
-        assert len(rv.json) == get_object_count("sources")
+        result = self.client.get("/api/sources/")
+        self.assertEqual(len(result.json), get_object_count("sources"))
         # check first record is expected source
-        assert rv.json[0]["gramps_id"] == "S0002"
-        assert rv.json[0]["handle"] == "VUBKMQTA2XZG1V6QP8"
-        assert rv.json[0]["title"] == "World of the Wierd"
+        self.assertEqual(result.json[0]["gramps_id"], "S0002")
+        self.assertEqual(result.json[0]["handle"], "VUBKMQTA2XZG1V6QP8")
+        self.assertEqual(result.json[0]["title"], "World of the Wierd")
         # check last record is expected source
-        last = len(rv.json) - 1
-        assert rv.json[last]["gramps_id"] == "S0001"
-        assert rv.json[last]["handle"] == "c140d4ef77841431905"
-        assert rv.json[last]["title"] == "All possible citations"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["gramps_id"], "S0001")
+        self.assertEqual(result.json[last]["handle"], "c140d4ef77841431905")
+        self.assertEqual(result.json[last]["title"], "All possible citations")
 
     def test_sources_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/sources/?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/sources/?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_sources_endpoint_gramps_id(self):
         """Test response for gramps_id parm."""
@@ -52,22 +52,20 @@ class TestSources(unittest.TestCase):
             "handle": "b39fe3f390e30bd2b99",
             "title": "Baptize registry 1850 - 1867 Great Falls Church",
         }
-        run_test_endpoint_gramps_id(self.client, "/api/sources/", driver)
+        run_test_endpoint_gramps_id(self, "/api/sources/", driver)
 
     def test_sources_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/sources/")
+        run_test_endpoint_strip(self, "/api/sources/")
 
     def test_sources_endpoint_keys(self):
         """Test response for keys parm."""
-        run_test_endpoint_keys(
-            self.client, "/api/sources/", ["author", "pubinfo", "title"]
-        )
+        run_test_endpoint_keys(self, "/api/sources/", ["author", "pubinfo", "title"])
 
     def test_sources_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client, "/api/sources/", ["abbrev", "reporef_list", "tag_list"]
+            self, "/api/sources/", ["abbrev", "reporef_list", "tag_list"]
         )
 
     def test_sources_endpoint_rules(self):
@@ -81,14 +79,18 @@ class TestSources(unittest.TestCase):
             404: ['{"rules":[{"name":"PigsInSpace"}]}'],
             200: [
                 '{"rules":[{"name":"HasNote"}]}',
-                '{"rules":[{"name":"MatchesTitleSubstringOf","values":["Church"]},{"name":"HasNote"}]}',
-                '{"function":"or","rules":[{"name":"MatchesTitleSubstringOf","values":["Church"]},{"name":"HasNote"}]}',
-                '{"function":"xor","rules":[{"name":"MatchesTitleSubstringOf","values":["Church"]},{"name":"HasNote"}]}',
-                '{"function":"one","rules":[{"name":"MatchesTitleSubstringOf","values":["Church"]},{"name":"HasNote"}]}',
+                '{"rules":[{"name":"MatchesTitleSubstringOf","values":["Church"]}'
+                + ',{"name":"HasNote"}]}',
+                '{"function":"or","rules":[{"name":"MatchesTitleSubstringOf",'
+                + '"values":["Church"]},{"name":"HasNote"}]}',
+                '{"function":"xor","rules":[{"name":"MatchesTitleSubstringOf",'
+                + '"values":["Church"]},{"name":"HasNote"}]}',
+                '{"function":"one","rules":[{"name":"MatchesTitleSubstringOf",'
+                + '"values":["Church"]},{"name":"HasNote"}]}',
                 '{"invert":true,"rules":[{"name":"HasNote"}]}',
             ],
         }
-        run_test_endpoint_rules(self.client, "/api/sources/", driver)
+        run_test_endpoint_rules(self, "/api/sources/", driver)
 
     def test_sources_endpoint_extend(self):
         """Test response for extend parm."""
@@ -98,16 +100,16 @@ class TestSources(unittest.TestCase):
             {"arg": "reporef_list", "key": "repositories", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/sources/", driver, ["S0000"])
+        run_test_endpoint_extend(self, "/api/sources/", driver, ["S0000"])
 
     def test_sources_endpoint_schema(self):
         """Test all sources against the source schema."""
-        rv = self.client.get("/api/sources/?extend=all")
+        result = self.client.get("/api/sources/?extend=all")
         # check expected number of sources found
-        assert len(rv.json) == get_object_count("sources")
+        self.assertEqual(len(result.json), get_object_count("sources"))
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for source in rv.json:
+        for source in result.json:
             validate(
                 instance=source,
                 schema=API_SCHEMA["definitions"]["Source"],
@@ -126,30 +128,30 @@ class TestSourcesHandle(unittest.TestCase):
     def test_sources_handle_endpoint_404(self):
         """Test response for a bad handle."""
         # check 404 returned for non-existent source
-        rv = self.client.get("/api/sources/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/sources/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_sources_handle_endpoint(self):
         """Test response for specific source."""
         # check expected source returned
-        rv = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX")
-        assert rv.json["gramps_id"] == "S0003"
-        assert rv.json["title"] == "Import from test2.ged"
+        result = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX")
+        self.assertEqual(result.json["gramps_id"], "S0003")
+        self.assertEqual(result.json["title"], "Import from test2.ged")
 
     def test_sources_handle_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned for bad parm
-        rv = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_sources_handle_endpoint_strip(self):
         """Test response for strip parm."""
-        run_test_endpoint_strip(self.client, "/api/sources/X5TJQC9JXU4RKT6VAX")
+        run_test_endpoint_strip(self, "/api/sources/X5TJQC9JXU4RKT6VAX")
 
     def test_sources_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self.client,
+            self,
             "/api/sources/X5TJQC9JXU4RKT6VAX",
             ["handle", "pubinfo", "title"],
         )
@@ -157,7 +159,7 @@ class TestSourcesHandle(unittest.TestCase):
     def test_sources_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self.client,
+            self,
             "/api/sources/X5TJQC9JXU4RKT6VAX",
             ["handle", "media_list", "private"],
         )
@@ -170,15 +172,15 @@ class TestSourcesHandle(unittest.TestCase):
             {"arg": "reporef_list", "key": "repositories", "type": List},
             {"arg": "tag_list", "key": "tags", "type": List},
         ]
-        run_test_endpoint_extend(self.client, "/api/sources/X5TJQC9JXU4RKT6VAX", driver)
+        run_test_endpoint_extend(self, "/api/sources/X5TJQC9JXU4RKT6VAX", driver)
 
     def test_sources_handle_endpoint_schema(self):
         """Test the source schema with extensions."""
         # check source record conforms to expected schema
-        rv = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX?extend=all")
+        result = self.client.get("/api/sources/X5TJQC9JXU4RKT6VAX?extend=all")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Source"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_tags.py
+++ b/tests/test_endpoints/test_tags.py
@@ -4,7 +4,7 @@ import unittest
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_object_count, get_test_client
+from tests.test_endpoints import API_SCHEMA, get_object_count, get_test_client
 
 
 class TestTags(unittest.TestCase):
@@ -18,20 +18,20 @@ class TestTags(unittest.TestCase):
     def test_tags_endpoint(self):
         """Test response for tags."""
         # check expected number of tags found
-        rv = self.client.get("/api/tags/")
-        assert len(rv.json) == get_object_count("tags")
+        result = self.client.get("/api/tags/")
+        self.assertEqual(len(result.json), get_object_count("tags"))
         # check first record is expected tag
-        assert rv.json[0]["name"] == "complete"
+        self.assertEqual(result.json[0]["name"], "complete")
         # check last record is expected tag
-        last = len(rv.json) - 1
-        assert rv.json[last]["name"] == "ToDo"
+        last = len(result.json) - 1
+        self.assertEqual(result.json[last]["name"], "ToDo")
 
     def test_tags_endpoint_schema(self):
         """Test all tags against the tag schema."""
         # check all records found conform to expected schema
-        rv = self.client.get("/api/tags/")
+        result = self.client.get("/api/tags/")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for tag in rv.json:
+        for tag in result.json:
             validate(
                 instance=tag, schema=API_SCHEMA["definitions"]["Tag"], resolver=resolver
             )
@@ -48,22 +48,22 @@ class TestTagsHandle(unittest.TestCase):
     def test_tags_handle_endpoint_404(self):
         """Test non-existent tag response."""
         # check 404 returned for non-existent tag
-        rv = self.client.get("/api/tags/does_not_exist")
-        assert rv.status_code == 404
+        result = self.client.get("/api/tags/does_not_exist")
+        self.assertEqual(result.status_code, 404)
 
     def test_tags_handle_endpoint(self):
         """Test tag response."""
         # check expected tag returned
-        rv = self.client.get("/api/tags/bb80c2b235b0a1b3f49")
-        assert rv.json["name"] == "ToDo"
+        result = self.client.get("/api/tags/bb80c2b235b0a1b3f49")
+        self.assertEqual(result.json["name"], "ToDo")
 
     def test_tag_handle_endpoint_schema(self):
         """Test the tag schema with extensions."""
         # check tag record conforms to expected schema
-        rv = self.client.get("/api/tags/bb80c2b235b0a1b3f49")
+        result = self.client.get("/api/tags/bb80c2b235b0a1b3f49")
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
-            instance=rv.json,
+            instance=result.json,
             schema=API_SCHEMA["definitions"]["Tag"],
             resolver=resolver,
         )

--- a/tests/test_endpoints/test_token.py
+++ b/tests/test_endpoints/test_token.py
@@ -2,9 +2,7 @@
 
 import unittest
 
-from jsonschema import validate
-
-from . import get_test_client
+from tests.test_endpoints import get_test_client
 
 
 class TestToken(unittest.TestCase):
@@ -17,12 +15,12 @@ class TestToken(unittest.TestCase):
 
     def test_token_endpoint(self):
         """Test login endpoint."""
-        response_value = self.client.post("/api/login/", data={})
-        assert response_value.status_code == 200
-        assert response_value.json == {"access_token": 1, "refresh_token": 1}
+        result = self.client.post("/api/login/", data={})
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json, {"access_token": 1, "refresh_token": 1})
 
     def test_refresh_token_endpoint(self):
         """Test refresh endpoint."""
-        response_value = self.client.post("/api/refresh/")
-        assert response_value.status_code == 200
-        assert response_value.json == {"access_token": 1}
+        result = self.client.post("/api/refresh/")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json, {"access_token": 1})

--- a/tests/test_endpoints/test_translations.py
+++ b/tests/test_endpoints/test_translations.py
@@ -4,7 +4,7 @@ import unittest
 
 from jsonschema import RefResolver, validate
 
-from . import API_SCHEMA, get_test_client
+from tests.test_endpoints import API_SCHEMA, get_test_client
 
 
 class TestTranslations(unittest.TestCase):
@@ -17,12 +17,12 @@ class TestTranslations(unittest.TestCase):
 
     def test_translations_endpoint_schema(self):
         """Test all translations against the translation schema."""
-        rv = self.client.get("/api/translations/")
+        result = self.client.get("/api/translations/")
         # check some minimum number of expected translations found
-        assert len(rv.json) >= 39
+        self.assertGreaterEqual(len(result.json), 39)
         # check all records found conform to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        for translation in rv.json:
+        for translation in result.json:
             validate(
                 instance=translation,
                 schema=API_SCHEMA["definitions"]["Translation"],
@@ -41,39 +41,43 @@ class TestTranslationsISOCode(unittest.TestCase):
     def test_translations_isocode_endpoint_422(self):
         """Test response for an invalid parm."""
         # check 422 returned if missing parm
-        rv = self.client.get("/api/translations/fr")
-        assert rv.status_code == 422
+        result = self.client.get("/api/translations/fr")
+        self.assertEqual(result.status_code, 422)
         # check 422 returned for bad parm
-        rv = self.client.get("/api/translations/fr?junk_parm=1")
-        assert rv.status_code == 422
+        result = self.client.get("/api/translations/fr?junk_parm=1")
+        self.assertEqual(result.status_code, 422)
 
     def test_translations_isocode_endpoint_404(self):
         """Test response for a unsupported iso code."""
         # check 404 returned for non-existent place
-        rv = self.client.get('/api/translations/fake?strings=["Birth"]')
-        assert rv.status_code == 404
+        result = self.client.get('/api/translations/fake?strings=["Birth"]')
+        self.assertEqual(result.status_code, 404)
 
     def test_translations_isocode_endpoint_400(self):
         """Test response for improperly formatted strings argument."""
         # check 404 returned for non-existent place
-        rv = self.client.get("/api/translations/fake?strings=[Birth]")
-        assert rv.status_code == 400
+        result = self.client.get("/api/translations/fake?strings=[Birth]")
+        self.assertEqual(result.status_code, 400)
 
     def test_translations_isocode_endpoint(self):
         """Test response for a translation."""
         # check a single expected translation was returned
-        rv = self.client.get('/api/translations/fr?strings=["Birth"]')
-        assert len(rv.json) == 1
-        assert rv.json[0] == {"original": "Birth", "translation": "Naissance"}
+        result = self.client.get('/api/translations/fr?strings=["Birth"]')
+        self.assertEqual(len(result.json), 1)
+        self.assertEqual(
+            result.json[0], {"original": "Birth", "translation": "Naissance"}
+        )
         # check multiple expected translations were returned
-        rv = self.client.get('/api/translations/fr?strings=["Birth", "Death"]')
-        assert len(rv.json) == 2
-        assert rv.json[0] == {"original": "Birth", "translation": "Naissance"}
-        assert rv.json[1] == {"original": "Death", "translation": "Décès"}
+        result = self.client.get('/api/translations/fr?strings=["Birth", "Death"]')
+        self.assertEqual(len(result.json), 2)
+        self.assertEqual(
+            result.json[0], {"original": "Birth", "translation": "Naissance"}
+        )
+        self.assertEqual(result.json[1], {"original": "Death", "translation": "Décès"})
 
     def test_translations_isocode_endpoint_separator(self):
         """Test expected response using - or _ separator in iso language code."""
-        rv = self.client.get('/api/translations/zh-TW?strings=["Marriage"]')
-        assert rv.json[0] == {"original": "Marriage", "translation": "婚姻"}
-        rv = self.client.get('/api/translations/zh_TW?strings=["Marriage"]')
-        assert rv.json[0] == {"original": "Marriage", "translation": "婚姻"}
+        result = self.client.get('/api/translations/zh-TW?strings=["Marriage"]')
+        self.assertEqual(result.json[0], {"original": "Marriage", "translation": "婚姻"})
+        result = self.client.get('/api/translations/zh_TW?strings=["Marriage"]')
+        self.assertEqual(result.json[0], {"original": "Marriage", "translation": "婚姻"})


### PR DESCRIPTION
@DavidMStraub this actually touches things in five areas, which I know you won't be thrilled about, but I just struggled with doing things one way for `test_filters.py` and not fixing the other test cases I put together to be conformant.

1. Changes `/api/filters` endpoint so delete now follows the more standard convention of having the item in the path as well as tweaks the two query parms on a get and `apispec.yaml` update.

2. The remainder of the `/api/filters` tests in `test_filters.py`. Those cover create / update / apply / delete of a custom filter for each endpoint. 

3. It replaces _all_ of the plain `asserts` in the test_endpoints modules with the more specific unittest ones like `assertEqual`, `assertTrue`, and `assertIn` which I realized I really should have done from the start.

4. It renames `rv` to `result` in all the test_endpoints modules along with other changes to try to appease pylint as best I could. 

5. It includes two changes to `.pylintrc` that I had to make as it refused to run at all on my machine. The first removes the duplicate [MESSAGES CONTROL] section at the bottom and the second changes fail-under=10.0 to fail-under=10 as pylint wanted it to be an integer. I am unsure on this one, it clearly must be working on your system. I'm using 2.6.0.

Sorry again for the size. I know you are working on test cases too and may be some collision there. So if you're stuff is ready to merge maybe do that first and I can rebase and revise this.  Let me know your thoughts.