### PR TITLE
Refactor /api/bookmarks for consistency with other endpoints (Closes #66)

### DIFF
--- a/gramps_webapi/api/resources/bookmark.py
+++ b/gramps_webapi/api/resources/bookmark.py
@@ -1,11 +1,51 @@
 """Bookmark API resource."""
 
+from typing import List, Optional
+
 from flask import Response, abort
 from gramps.gen.db.base import DbReadBase
 
 from ..util import get_dbstate
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
+
+_BOOKMARK_TYPES = [
+    "citations",
+    "events",
+    "families",
+    "media",
+    "notes",
+    "people",
+    "places",
+    "repositories",
+    "sources",
+]
+
+
+def get_bookmarks(db_handle: DbReadBase, namespace: str) -> Optional[List]:
+    """Return bookmarks for a namespace."""
+    result = None
+    if namespace == "people":
+        result = db_handle.get_bookmarks()
+    elif namespace == "families":
+        result = db_handle.get_family_bookmarks()
+    elif namespace == "media":
+        result = db_handle.get_media_bookmarks()
+    elif namespace == "events":
+        result = db_handle.get_event_bookmarks()
+    elif namespace == "citations":
+        result = db_handle.get_citation_bookmarks()
+    elif namespace == "notes":
+        result = db_handle.get_note_bookmarks()
+    elif namespace == "places":
+        result = db_handle.get_place_bookmarks()
+    elif namespace == "sources":
+        result = db_handle.get_source_bookmarks()
+    elif namespace == "repositories":
+        result = db_handle.get_repo_bookmarks()
+    if result is None:
+        abort(404)
+    return result.get()
 
 
 class BookmarkResource(ProtectedResource, GrampsJSONEncoder):
@@ -18,48 +58,20 @@ class BookmarkResource(ProtectedResource, GrampsJSONEncoder):
 
     def get(self, namespace: str) -> Response:
         """Get list of bookmarks by namespace."""
-        db_handle = self.db_handle
-        if namespace == "people":
-            result = db_handle.get_bookmarks()
-        elif namespace == "families":
-            result = db_handle.get_family_bookmarks()
-        elif namespace == "media":
-            result = db_handle.get_media_bookmarks()
-        elif namespace == "events":
-            result = db_handle.get_event_bookmarks()
-        elif namespace == "citations":
-            result = db_handle.get_citation_bookmarks()
-        elif namespace == "notes":
-            result = db_handle.get_note_bookmarks()
-        elif namespace == "places":
-            result = db_handle.get_place_bookmarks()
-        elif namespace == "sources":
-            result = db_handle.get_source_bookmarks()
-        elif namespace == "repositories":
-            result = db_handle.get_repo_bookmarks()
-        else:
-            abort(404)
-        return self.response(200, result)
+        return self.response(200, get_bookmarks(self.db_handle, namespace))
 
 
 class BookmarksResource(ProtectedResource, GrampsJSONEncoder):
     """Bookmarks resource."""
 
+    @property
+    def db_handle(self) -> DbReadBase:
+        """Get the database instance."""
+        return get_dbstate().db
+
     def get(self) -> Response:
         """Get the list of bookmark types."""
-        return self.response(
-            200,
-            {
-                "namespaces": [
-                    "citations",
-                    "events",
-                    "families",
-                    "media",
-                    "notes",
-                    "people",
-                    "places",
-                    "repositories",
-                    "sources",
-                ]
-            },
-        )
+        result = {}
+        for bookmark in _BOOKMARK_TYPES:
+            result.update({bookmark: get_bookmarks(self.db_handle, bookmark)})
+        return self.response(200, result)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1943,15 +1943,15 @@ paths:
     get:
       tags:
       - bookmarks
-      summary: "Get a list of bookmark categories."
-      operationId: getBookmarkCategories
+      summary: "Get all bookmarks."
+      operationId: getAllBookmarks
       security:
         - Bearer: []
       responses:
         200:
           description: "OK: Successful operation."
           schema:
-            $ref: "#/definitions/NameSpaces"
+            $ref: "#/definitions/Bookmarks"
         401:
           description: "Unauthorized: Missing authorization header."
 
@@ -1973,7 +1973,13 @@ paths:
         200:
           description: "OK: Successful operation."
           schema:
-            $ref: "#/definitions/Bookmarks"
+            type: array
+            items:
+              type: string
+          example:
+            - AWFKQCJELLUWDY2PD3
+            - 35WJQC1B7T7NPV8OLV
+            - Q8HKQC3VMRM1M6M7ES
         401:
           description: "Unauthorized: Missing authorization header."
         404:
@@ -4425,14 +4431,17 @@ definitions:
 
   Bookmarks:
     type: object
-    properties:
-      bookmarks:
-        type: array
-        items:
-          type: string
-        example:
-          - e9027bf5e7f77551b12e7da3c77
-          - e9027bf3de2402f9faaac001cef
+    additionalProperties:
+      type: array
+      items:
+        type: string
+    example:
+      families:
+        - 9OUJQCBOHW9UEK9CNV
+      people:
+        - AWFKQCJELLUWDY2PD3
+        - 35WJQC1B7T7NPV8OLV
+        - Q8HKQC3VMRM1M6M7ES
 
 ##############################################################################
 # Model - NameGroupMapping

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1976,10 +1976,6 @@ paths:
             type: array
             items:
               type: string
-          example:
-            - AWFKQCJELLUWDY2PD3
-            - 35WJQC1B7T7NPV8OLV
-            - Q8HKQC3VMRM1M6M7ES
         401:
           description: "Unauthorized: Missing authorization header."
         404:

--- a/tests/test_endpoints/test_bookmarks.py
+++ b/tests/test_endpoints/test_bookmarks.py
@@ -17,33 +17,18 @@ class TestBookmarks(unittest.TestCase):
 
     def test_bookmarks_endpoint_schema(self):
         """Test bookmarks against the bookmark schema."""
-        # check one response returned for namespace list
+        # check response conforms to schema
         result = self.client.get("/api/bookmarks/")
-        self.assertEqual(len(result.json), 1)
-        # check record conforms to expected schema
         resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
         validate(
             instance=result.json,
-            schema=API_SCHEMA["definitions"]["NameSpaces"],
+            schema=API_SCHEMA["definitions"]["Bookmarks"],
             resolver=resolver,
         )
-        # check one response returned for families
+        # check bad entry returns 404
+        result = self.client.get("/api/bookmarks/junk")
+        self.assertEqual(result.status_code, 404)
+        # check valid response returned for families
         result = self.client.get("/api/bookmarks/families")
-        self.assertEqual(len(result.json), 1)
-        # check record conforms to expected schema
-        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        validate(
-            instance=result.json,
-            schema=API_SCHEMA["definitions"]["Bookmarks"],
-            resolver=resolver,
-        )
-        # check one response returned for people
-        result = self.client.get("/api/bookmarks/people")
-        self.assertEqual(len(result.json), 1)
-        # check record conforms to expected schema
-        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
-        validate(
-            instance=result.json,
-            schema=API_SCHEMA["definitions"]["Bookmarks"],
-            resolver=resolver,
-        )
+        self.assertEqual(result.status_code, 200)
+        self.assertIsInstance(result.json[0], str)


### PR DESCRIPTION
This one is self contained and refactors /api/bookmarks to return all of them and then drill down to specific set to be consistent with the other endpoints based on discussion about PR #63 