### PR TITLE
Add /api/reports endpoint (Closes #67)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -48,7 +48,7 @@ from .resources.notes import NoteResource, NotesResource
 from .resources.people import PeopleResource, PersonResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
-from .resources.reports import ReportResource, ReportRunnerResource, ReportsResource
+from .resources.reports import ReportFileResource, ReportResource, ReportsResource
 from .resources.repositories import RepositoriesResource, RepositoryResource
 from .resources.sources import SourceResource, SourcesResource
 from .resources.tags import TagResource, TagsResource
@@ -144,7 +144,7 @@ register_endpt(
     "relations",
 )
 # Reports
-register_endpt(ReportRunnerResource, "/reports/<string:report_id>/file", "run-report")
+register_endpt(ReportFileResource, "/reports/<string:report_id>/file", "report-file")
 register_endpt(ReportResource, "/reports/<string:report_id>", "report")
 register_endpt(ReportsResource, "/reports/", "reports")
 # Exporters

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -144,8 +144,8 @@ register_endpt(
     "relations",
 )
 # Reports
-register_endpt(ReportRunnerResource, "/reports/<string:id>/file", "run-report")
-register_endpt(ReportResource, "/reports/<string:id>", "report")
+register_endpt(ReportRunnerResource, "/reports/<string:report_id>/file", "run-report")
+register_endpt(ReportResource, "/reports/<string:report_id>", "report")
 register_endpt(ReportsResource, "/reports/", "reports")
 # Exporters
 register_endpt(

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -48,6 +48,7 @@ from .resources.notes import NoteResource, NotesResource
 from .resources.people import PeopleResource, PersonResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
+from .resources.reports import ReportResource, ReportRunnerResource, ReportsResource
 from .resources.repositories import RepositoriesResource, RepositoryResource
 from .resources.sources import SourceResource, SourcesResource
 from .resources.tags import TagResource, TagsResource
@@ -142,6 +143,10 @@ register_endpt(
     "/relations/<string:handle1>/<string:handle2>/all",
     "relations",
 )
+# Reports
+register_endpt(ReportsResource, "/reports/", "reports")
+register_endpt(ReportResource, "/reports/<string:id>", "report")
+register_endpt(ReportRunnerResource, "/reports/<string:id>/file", "run-report")
 # Exporters
 register_endpt(
     ExporterFileResource, "/exporters/<string:extension>/file", "exporter-file"

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -144,9 +144,9 @@ register_endpt(
     "relations",
 )
 # Reports
-register_endpt(ReportsResource, "/reports/", "reports")
-register_endpt(ReportResource, "/reports/<string:id>", "report")
 register_endpt(ReportRunnerResource, "/reports/<string:id>/file", "run-report")
+register_endpt(ReportResource, "/reports/<string:id>", "report")
+register_endpt(ReportsResource, "/reports/", "reports")
 # Exporters
 register_endpt(
     ExporterFileResource, "/exporters/<string:extension>/file", "exporter-file"

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -1,0 +1,214 @@
+"""Reports Plugin API resource."""
+
+import io
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import BinaryIO, Dict
+
+from flask import Response, abort, send_file
+from gramps.cli.plug import CommandLineReport, cl_report
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.filters import reload_custom_filters
+from gramps.gen.plug import CATEGORY_BOOK, CATEGORY_WEB, BasePluginManager
+from gramps.gen.utils.resourcepath import ResourcePath
+from webargs import fields, validate
+from webargs.flaskparser import use_args
+
+from ...const import REPORT_DEFAULTS, REPORT_MIMETYPES
+from ..util import get_dbstate
+from . import ProtectedResource
+from .emit import GrampsJSONEncoder
+
+_UNSUPPORTED = [CATEGORY_WEB, CATEGORY_BOOK]
+
+_EXTENSION_MAP = {"gvpdf": "pdf", "gspdf": "pdf"}
+
+
+def get_report_profile(
+    db_handle: DbReadBase, plugin_manager: BasePluginManager, report_data
+):
+    """Extract and return report attributes and options."""
+    module = plugin_manager.load_plugin(report_data)
+    option_class = getattr(module, report_data.optionclass)
+    report = CommandLineReport(
+        db_handle, report_data.name, report_data.category, option_class, {}
+    )
+    return {
+        "id": report_data.id,
+        "name": report_data.name,
+        "name_accell": report_data.name_accell,
+        "description": report_data.description,
+        "version": report_data.version,
+        "status": report_data.status,
+        "fname": report_data.fname,
+        "fpath": report_data.fpath,
+        "ptype": report_data.ptype,
+        "authors": report_data.authors,
+        "authors_email": report_data.authors_email,
+        "supported": report_data.supported,
+        "load_on_reg": report_data.load_on_reg,
+        "icons": report_data.icons,
+        "icondir": report_data.icondir,
+        "category": report_data.category,
+        "module": report_data.mod_name,
+        "reportclass": report_data.reportclass,
+        "require_active": report_data.require_active,
+        "report_modes": report_data.report_modes,
+        "option_class": report_data.optionclass,
+        "options_dict": report.options_dict,
+        "options_help": report.options_help,
+    }
+
+
+def get_reports(db_handle: DbReadBase, report_id: str = None):
+    """Extract and return report attributes and options."""
+    reload_custom_filters()
+    plugin_manager = BasePluginManager.get_instance()
+    reports = []
+    for report_data in plugin_manager.get_reg_reports(gui=False):
+        if report_id is not None and report_data.id != report_id:
+            continue
+        if report_data.category in _UNSUPPORTED:
+            continue
+        report = get_report_profile(db_handle, plugin_manager, report_data)
+        reports.append(report)
+    return reports
+
+
+def run_report(db_handle: DbReadBase, report_id: str, report_options: Dict):
+    """Generate the report."""
+    _resources = ResourcePath()
+    os.environ["GRAMPS_RESOURCES"] = str(Path(_resources.data_dir).parent)
+    reload_custom_filters()
+    plugin_manager = BasePluginManager.get_instance()
+    for report_data in plugin_manager.get_reg_reports(gui=False):
+        if report_data.id == report_id:
+            if report_data.category in _UNSUPPORTED:
+                abort(404)
+            if "off" not in report_options:
+                report_options["off"] = REPORT_DEFAULTS[report_data.category]
+            file_type = report_options["off"]
+            if file_type in _EXTENSION_MAP:
+                file_name = str(uuid.uuid4()) + "." + _EXTENSION_MAP[file_type]
+            else:
+                file_name = str(uuid.uuid4()) + "." + file_type
+            report_options["of"] = file_name
+            report_profile = get_report_profile(db_handle, plugin_manager, report_data)
+            validate_options(report_profile, report_options)
+            module = plugin_manager.load_plugin(report_data)
+            option_class = getattr(module, report_data.optionclass)
+            report_class = getattr(module, report_data.reportclass)
+            cl_report(
+                db_handle,
+                report_data.name,
+                report_data.category,
+                report_class,
+                option_class,
+                report_options,
+            )
+            return file_name, file_type
+    abort(404)
+
+
+def validate_options(report: Dict, report_options: Dict):
+    """Check validity of provided report options."""
+    if report["id"] == "familylines_graph":
+        if "gidlist" not in report_options or not report_options["gidlist"]:
+            abort(422)
+    for option in report_options:
+        if option not in report["options_dict"]:
+            abort(422)
+        if isinstance(report["options_help"][option][2], type([])):
+            option_list = []
+            for item in report["options_help"][option][2]:
+                if "\t" in item:
+                    option_list.append(item.split("\t")[0])
+                else:
+                    option_list.append(item)
+            if report_options[option] not in option_list:
+                abort(422)
+            continue
+        if not isinstance(report_options[option], str):
+            abort(422)
+        if "A number" in report["options_help"][option][2]:
+            try:
+                int(report_options[option])
+            except ValueError:
+                abort(422)
+        if "Size in cm" in report["options_help"][option][2]:
+            try:
+                float(report_options[option])
+            except ValueError:
+                abort(422)
+
+
+def fetch_buffer(filename: str, delete=True) -> BinaryIO:
+    """Pull file into a binary buffer."""
+    try:
+        with open(filename, "rb") as file_handle:
+            buffer = io.BytesIO(file_handle.read())
+    except FileNotFoundError:
+        abort(500)
+    if delete:
+        os.remove(filename)
+    return buffer
+
+
+class ReportsResource(ProtectedResource, GrampsJSONEncoder):
+    """Reports resource."""
+
+    @property
+    def db_handle(self) -> DbReadBase:
+        """Get the database instance."""
+        return get_dbstate().db
+
+    def get(self) -> Response:
+        """Get all available report attributes."""
+        reports = get_reports(self.db_handle)
+        return self.response(200, reports)
+
+
+class ReportResource(ProtectedResource, GrampsJSONEncoder):
+    """Report resource."""
+
+    @property
+    def db_handle(self) -> DbReadBase:
+        """Get the database instance."""
+        return get_dbstate().db
+
+    def get(self, id: str) -> Response:
+        """Get specific report attributes."""
+        reports = get_reports(self.db_handle, report_id=id)
+        if reports == []:
+            abort(404)
+        return self.response(200, reports[0])
+
+
+class ReportRunnerResource(ProtectedResource, GrampsJSONEncoder):
+    """Report runner resource."""
+
+    @property
+    def db_handle(self) -> DbReadBase:
+        """Get the database instance."""
+        return get_dbstate().db
+
+    @use_args(
+        {
+            "options": fields.Str(validate=validate.Length(min=1)),
+        },
+        location="query",
+    )
+    def get(self, args: Dict, id: str) -> Response:
+        """Get specific report attributes."""
+        report_options = {}
+        if "options" in args:
+            try:
+                report_options = json.loads(args["options"])
+            except json.JSONDecodeError:
+                abort(400)
+
+        file_name, file_type = run_report(self.db_handle, id, report_options)
+        buffer = fetch_buffer(file_name)
+        return send_file(buffer, mimetype=REPORT_MIMETYPES[file_type])

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -42,7 +42,7 @@ from ..util import get_buffer_for_file, get_dbstate
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
-_EXTENSION_MAP = {".gvpdf": ".pdf", ".gspdf": ".pdf"}
+_EXTENSION_MAP = {".gvpdf": ".pdf", ".gspdf": ".pdf", ".dot": ".gv"}
 
 
 def get_report_profile(
@@ -171,42 +171,27 @@ def validate_options(report: Dict, report_options: Dict, allow_file: bool = Fals
 class ReportsResource(ProtectedResource, GrampsJSONEncoder):
     """Reports resource."""
 
-    @property
-    def db_handle(self) -> DbReadBase:
-        """Get the database instance."""
-        return get_dbstate().db
-
     @use_args({}, location="query")
     def get(self, args: Dict) -> Response:
         """Get all available report attributes."""
-        reports = get_reports(self.db_handle)
+        reports = get_reports(get_dbstate().db)
         return self.response(200, reports)
 
 
 class ReportResource(ProtectedResource, GrampsJSONEncoder):
     """Report resource."""
 
-    @property
-    def db_handle(self) -> DbReadBase:
-        """Get the database instance."""
-        return get_dbstate().db
-
     @use_args({}, location="query")
     def get(self, args: Dict, report_id: str) -> Response:
         """Get specific report attributes."""
-        reports = get_reports(self.db_handle, report_id=report_id)
+        reports = get_reports(get_dbstate().db, report_id=report_id)
         if reports == []:
             abort(404)
         return self.response(200, reports[0])
 
 
-class ReportRunnerResource(ProtectedResource, GrampsJSONEncoder):
-    """Report runner resource."""
-
-    @property
-    def db_handle(self) -> DbReadBase:
-        """Get the database instance."""
-        return get_dbstate().db
+class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
+    """Report file resource."""
 
     @use_args(
         {
@@ -225,6 +210,6 @@ class ReportRunnerResource(ProtectedResource, GrampsJSONEncoder):
         if "of" in report_options:
             abort(422)
 
-        file_name, file_type = run_report(self.db_handle, report_id, report_options)
+        file_name, file_type = run_report(get_dbstate().db, report_id, report_options)
         buffer = get_buffer_for_file(file_name)
         return send_file(buffer, mimetype=types_map[file_type])

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -21,15 +21,7 @@
 """Constants for the web API."""
 
 import gramps.gen.lib as lib
-from gramps.gen.plug import (
-    CATEGORY_BOOK,
-    CATEGORY_CODE,
-    CATEGORY_DRAW,
-    CATEGORY_GRAPHVIZ,
-    CATEGORY_TEXT,
-    CATEGORY_TREE,
-    CATEGORY_WEB,
-)
+from gramps.gen.plug import CATEGORY_DRAW, CATEGORY_GRAPHVIZ, CATEGORY_TEXT
 from pkg_resources import resource_filename
 
 from ._version import __version__ as VERSION
@@ -88,13 +80,19 @@ GRAMPS_NAMESPACES = {
 MIME_PDF = "application/pdf"
 MIME_JPEG = "image/jpeg"
 
-# Mapping of defaults based on report category
-REPORT_DEFAULTS = {
-    CATEGORY_TEXT: "pdf",
-    CATEGORY_DRAW: "pdf",
-    CATEGORY_GRAPHVIZ: "gvpdf",
-    CATEGORY_BOOK: "pdf",
-    CATEGORY_TREE: "pdf",
-    CATEGORY_CODE: "pdf",
-    CATEGORY_WEB: "html",
-}
+# These determine the supported report categories and default formats
+# depending on whether needed dependencies are available.
+try:
+    import gi
+
+    REPORT_DEFAULTS = {
+        CATEGORY_TEXT: "pdf",
+        CATEGORY_DRAW: "pdf",
+        CATEGORY_GRAPHVIZ: "gspdf",
+    }
+    REPORT_FILTERS = []
+except ImportError:
+    REPORT_DEFAULTS = {
+        CATEGORY_TEXT: "rtf",
+    }
+    REPORT_FILTERS = ["pdf", "ps", "gspdf", "gvpdf"]

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -87,38 +87,6 @@ GRAMPS_NAMESPACES = {
 # MIME types
 MIME_PDF = "application/pdf"
 MIME_JPEG = "image/jpeg"
-MIME_GIF = "image/gif"
-MIME_PNG = "image/png"
-MIME_TEXT = "text/plain"
-MIME_HTML = "text/html"
-MIME_TEX = "application/x-tex"
-MIME_ODT = "application/vnd.oasis.opendocument.text"
-MIME_PS = "application/postscript"
-MIME_RTF = "application/rtf"
-MIME_DOT = "application/octet-stream"
-MIME_SVG = "image/svg+xml"
-MIME_SVGZ = "image/svg+xml"
-MIME_GSPDF = "application/pdf"
-MIME_GVPDF = "application/pdf"
-
-# Mapping of report output file formats to MIME types
-REPORT_MIMETYPES = {
-    "txt": MIME_TEXT,
-    "html": MIME_HTML,
-    "tex": MIME_TEX,
-    "odt": MIME_ODT,
-    "pdf": MIME_PDF,
-    "ps": MIME_PS,
-    "rtf": MIME_RTF,
-    "dot": MIME_DOT,
-    "gspdf": MIME_GSPDF,
-    "gvpdf": MIME_GVPDF,
-    "svg": MIME_SVG,
-    "svgz": MIME_SVGZ,
-    "jpg": MIME_JPEG,
-    "gif": MIME_GIF,
-    "png": MIME_PNG,
-}
 
 # Mapping of defaults based on report category
 REPORT_DEFAULTS = {

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -20,6 +20,8 @@
 
 """Constants for the web API."""
 
+import shutil
+
 import gramps.gen.lib as lib
 from gramps.gen.plug import CATEGORY_DRAW, CATEGORY_GRAPHVIZ, CATEGORY_TEXT
 from pkg_resources import resource_filename
@@ -85,14 +87,16 @@ MIME_JPEG = "image/jpeg"
 try:
     import gi
 
+    REPORT_FILTERS = ["dot", "gvpdf"]
     REPORT_DEFAULTS = {
         CATEGORY_TEXT: "pdf",
         CATEGORY_DRAW: "pdf",
-        CATEGORY_GRAPHVIZ: "gspdf",
     }
-    REPORT_FILTERS = []
+    if shutil.which("dot") is not None:
+        REPORT_FILTERS = []
+        REPORT_DEFAULTS[CATEGORY_GRAPHVIZ] = "dot"
 except ImportError:
+    REPORT_FILTERS = ["pdf", "ps", "gspdf", "gvpdf"]
     REPORT_DEFAULTS = {
         CATEGORY_TEXT: "rtf",
     }
-    REPORT_FILTERS = ["pdf", "ps", "gspdf", "gvpdf"]

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -21,6 +21,15 @@
 """Constants for the web API."""
 
 import gramps.gen.lib as lib
+from gramps.gen.plug import (
+    CATEGORY_BOOK,
+    CATEGORY_CODE,
+    CATEGORY_DRAW,
+    CATEGORY_GRAPHVIZ,
+    CATEGORY_TEXT,
+    CATEGORY_TREE,
+    CATEGORY_WEB,
+)
 from pkg_resources import resource_filename
 
 from ._version import __version__ as VERSION
@@ -78,3 +87,46 @@ GRAMPS_NAMESPACES = {
 # MIME types
 MIME_PDF = "application/pdf"
 MIME_JPEG = "image/jpeg"
+MIME_GIF = "image/gif"
+MIME_PNG = "image/png"
+MIME_TEXT = "text/plain"
+MIME_HTML = "text/html"
+MIME_TEX = "application/x-tex"
+MIME_ODT = "application/vnd.oasis.opendocument.text"
+MIME_PS = "application/postscript"
+MIME_RTF = "application/rtf"
+MIME_DOT = "application/octet-stream"
+MIME_SVG = "image/svg+xml"
+MIME_SVGZ = "image/svg+xml"
+MIME_GSPDF = "application/pdf"
+MIME_GVPDF = "application/pdf"
+
+# Mapping of report output file formats to MIME types
+REPORT_MIMETYPES = {
+    "txt": MIME_TEXT,
+    "html": MIME_HTML,
+    "tex": MIME_TEX,
+    "odt": MIME_ODT,
+    "pdf": MIME_PDF,
+    "ps": MIME_PS,
+    "rtf": MIME_RTF,
+    "dot": MIME_DOT,
+    "gspdf": MIME_GSPDF,
+    "gvpdf": MIME_GVPDF,
+    "svg": MIME_SVG,
+    "svgz": MIME_SVGZ,
+    "jpg": MIME_JPEG,
+    "gif": MIME_GIF,
+    "png": MIME_PNG,
+}
+
+# Mapping of defaults based on report category
+REPORT_DEFAULTS = {
+    CATEGORY_TEXT: "pdf",
+    CATEGORY_DRAW: "pdf",
+    CATEGORY_GRAPHVIZ: "gvpdf",
+    CATEGORY_BOOK: "pdf",
+    CATEGORY_TREE: "pdf",
+    CATEGORY_CODE: "pdf",
+    CATEGORY_WEB: "html",
+}

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5583,47 +5583,14 @@ definitions:
         description: "A description of the report."
         type: string
         example: "Produces a textual ancestral report"
-      fname:
-        description: "Filename of the report module."
-        type: string
-        example: "ancestorreport.py"
-      fpath:
-        description: "Path of directory report module is located in."
-        type: string
-        example: "/usr/lib/python3.8/site-packages/gramps/plugins/textreport"
-      icondir:
-        description: "Path to directory any needed report icons are located in."
-        type: string
-        example: ""
-      icons:
-        description: "A list of icons needed by the report."
-        type: array
-        items:
-          type: string
       id:
         description: "The report identifier."
         type: string
         example: "ancestor_report"
-      load_on_reg:
-        description: "Indicates if plugin should load on registration."
-        type: boolean
-        example: false
-      module:
-        description: "The name of the report module."
-        type: string
-        example: "ancestorreport"
       name:
         description: "The name of the report."
         type: string
         example: "Ahnentafel Report"
-      name_accell:
-        description: "The name of the report."
-        type: string
-        example: "Ahnentafel Report"
-      option_class:
-        description: "The name of the option class for the report."
-        type: string
-        example: "AncestorOptions"
       options_dict:
         description: "Dictionary containing all of the report options with their defaults."
         type: object
@@ -5642,10 +5609,6 @@ definitions:
             -
               - "0\t"
               - "1\t"
-      ptype:
-        description: "Plugin type"
-        type: integer
-        example: 0
       report_modes:
         description: "List of report modes."
         type: array
@@ -5655,22 +5618,6 @@ definitions:
           - 1
           - 2
           - 4
-      reportclass:
-        description: "The name of the report class for the report."
-        type: string
-        example: "AncestorReport"
-      require_active:
-        description: "Indicator if user interaction required."
-        type: boolean
-        example: true
-      status:
-        description: "Indicate current status of the report."
-        type: integer
-        example: 0
-      supported:
-        description: "Indicate if the report is still supported."
-        type: boolean
-        example: true
       version:
         description: "The version number of the report."
         type: string

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5594,7 +5594,7 @@ definitions:
       icondir:
         description: "Path to directory any needed report icons are located in."
         type: string
-        example: null
+        example: ""
       icons:
         description: "A list of icons needed by the report."
         type: array

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -2709,7 +2709,7 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
-  /reports/{id}:
+  /reports/{report_id}:
     get:
       tags:
       - reports
@@ -2718,7 +2718,7 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: id
+      - name: report_id
         in: path
         required: true
         type: string
@@ -2731,7 +2731,7 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
-  /reports/{id}/file:
+  /reports/{report_id}/file:
     get:
       tags:
       - reports
@@ -2740,7 +2740,7 @@ paths:
       security:
         - Bearer: []
       parameters:
-      - name: id
+      - name: report_id
         in: path
         required: true
         type: string
@@ -2749,7 +2749,17 @@ paths:
         in: query
         required: false
         type: string
-        description: "The report options. Must be provided in JSON format."
+        description: >
+          The report options. Must be provided in JSON format.
+
+
+          There are a core set of options common to all reports, and then sometimes additional options
+          specific to a given report. A few reports do not have defaults for all options and require
+          some be specified in order to run properly.
+
+    
+          If no _off_ option for report output file format is provided then pdf will be used as a fallback.
+          The _of_ option for output file is ignored by this endpoint as the report file is ephemeral.
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -6,7 +6,7 @@ info:
 
     * The Gramps Web API project is hosted at https://github.com/gramps-project/web-api
 
-   
+
     * More about Gramps and the numerous features it provides for genealogists can be found at https://gramps-project.org
   version: "0.1.0"
   license:
@@ -62,6 +62,8 @@ tags:
   description: Access to translation service.
 - name: relations
   description: Access to relationship calculator.
+- name: reports
+  description: Access to report generating service.
 - name: exporters
   description: Access to family tree exporters.
 - name: metadata
@@ -2685,6 +2687,77 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
+##############################################################################    
+# Endpoint - Reports
+##############################################################################
+
+  /reports:
+    get:
+      tags:
+      - reports
+      summary: "Get information about available reports."
+      operationId: getAllReports
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Report"
+        401:
+          description: "Unauthorized: Missing authorization header."
+
+  /reports/{id}:
+    get:
+      tags:
+      - reports
+      summary: "Get information about a specific report."
+      operationId: getReport
+      security:
+        - Bearer: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: "The report identifier."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/Report"
+        401:
+          description: "Unauthorized: Missing authorization header."
+
+  /reports/{id}/file:
+    get:
+      tags:
+      - reports
+      summary: "Get a specific report."
+      operationId: getReportFile
+      security:
+        - Bearer: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: "The report identifier."
+      - name: options
+        in: query
+        required: false
+        type: string
+        description: "The report options. Must be provided in JSON format."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+
 ##############################################################################
 # Endpoint - Exporters
 ##############################################################################
@@ -2724,7 +2797,7 @@ paths:
       responses:
         200:
           description: "OK: Successful operation."
-          schema:
+          schema:    
             $ref: "#/definitions/Exporter"
         401:
           description: "Unauthorized: Missing authorization header."
@@ -2891,6 +2964,7 @@ paths:
             type: file
         401:
           description: "Unauthorized: Missing authorization header."
+    
         404:
           description: "Not Found: Exporter not found."
         422:
@@ -5330,7 +5404,6 @@ definitions:
       source_media_types:
         - Microfilm
 
-
 ##############################################################################
 # Model - Backlinks
 ##############################################################################
@@ -5470,3 +5543,140 @@ definitions:
         description: "The module name of the exporter plugin."
         type: string
         example: "exportxml"
+
+##############################################################################    
+# Model - Report
+##############################################################################
+
+  Report:
+    type: object
+    properties:
+      authors:
+        description: "Report authors."
+        type: array
+        items:
+          type: string
+        example: 
+          - "Donald N. Allingham"
+      authors_email:
+        description: "Email addresses for report authors."
+        type: array
+        items:
+          type: string
+        example:
+          - "don@gramps-project.org"
+      category:
+        description: "The report category."
+        type: integer
+        example: 0
+      description:
+        description: "A description of the report."
+        type: string
+        example: "Produces a textual ancestral report"
+      fname:
+        description: "Filename of the report module."
+        type: string
+        example: "ancestorreport.py"
+      fpath:
+        description: "Path of directory report module is located in."
+        type: string
+        example: "/usr/lib/python3.8/site-packages/gramps/plugins/textreport"
+      icondir:
+        description: "Path to directory any needed report icons are located in."
+        type: string
+        example: null
+      icons:
+        description: "A list of icons needed by the report."
+        type: array
+        items:
+          type: string
+      id:
+        description: "The report identifier."
+        type: string
+        example: "ancestor_report"
+      load_on_reg:
+        description: "Indicates if plugin should load on registration."
+        type: boolean
+        example: false
+      module:
+        description: "The name of the report module."
+        type: string
+        example: "ancestorreport"
+      name:
+        description: "The name of the report."
+        type: string
+        example: "Ahnentafel Report"
+      name_accell:
+        description: "The name of the report."
+        type: string
+        example: "Ahnentafel Report"
+      option_class:
+        description: "The name of the option class for the report."
+        type: string
+        example: "AncestorOptions"
+      options_dict:
+        description: "Dictionary containing all of the report options with their defaults."
+        type: object
+        additionalProperties: true
+        example: 
+          papero: 0        
+      options_help:
+        description: "Dictionary containing help information for all of the report options."
+        type: object
+        additionalProperties:
+          $ref: "#/definitions/ReportHelpOption"
+        example:
+          papero:
+            - "=number"
+            - "Paper orientation number."
+            -
+              - "0\t"
+              - "1\t"
+      ptype:
+        description: "Plugin type"
+        type: integer
+        example: 0
+      report_modes:
+        description: "List of report modes."
+        type: array
+        items:
+          type: integer
+        example:
+          - 1
+          - 2
+          - 4
+      reportclass:
+        description: "The name of the report class for the report."
+        type: string
+        example: "AncestorReport"
+      require_active:
+        description: "Indicator if user interaction required."
+        type: boolean
+        example: true
+      status:
+        description: "Indicate current status of the report."
+        type: integer
+        example: 0
+      supported:
+        description: "Indicate if the report is still supported."
+        type: boolean
+        example: true
+      version:
+        description: "The version number of the report."
+        type: string
+        example: "1.0"
+
+##############################################################################
+# Model - ReportHelpOption
+##############################################################################
+
+  ReportHelpOption:
+    type: array
+    items: {}
+    example:
+      - "=number"
+      - "Paper orientation number."
+      -
+        - "0\t"
+        - "1\t"
+

--- a/tests/test_endpoints/test_reports.py
+++ b/tests/test_endpoints/test_reports.py
@@ -5,6 +5,8 @@ from mimetypes import types_map
 
 from jsonschema import RefResolver, validate
 
+from gramps_webapi.const import REPORT_DEFAULTS
+
 from . import API_SCHEMA, get_test_client
 
 
@@ -80,7 +82,8 @@ class TestReportFile(unittest.TestCase):
         # check response for valid report
         result = self.client.get("/api/reports/ancestor_report/file")
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.mimetype, types_map[".pdf"])
+        mime_type = "." + REPORT_DEFAULTS[0]
+        self.assertEqual(result.mimetype, types_map[mime_type])
         # check bad query parm response
         result = self.client.get("/api/reports/ancestor_report/file?test=1")
         self.assertEqual(result.status_code, 422)
@@ -144,10 +147,10 @@ class TestReportFile(unittest.TestCase):
         self.assertEqual(result.status_code, 422)
         # check different output format accepted and processed properly
         result = self.client.get(
-            '/api/reports/ancestor_report/file?options={"off": "rtf"}'
+            '/api/reports/ancestor_report/file?options={"off": "odt"}'
         )
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.mimetype, types_map[".rtf"])
+        self.assertEqual(result.mimetype, types_map[".odt"])
 
     def test_reports_report_id_file_each_one(self):
         """Test one of each available report."""

--- a/tests/test_endpoints/test_reports.py
+++ b/tests/test_endpoints/test_reports.py
@@ -1,3 +1,23 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 """Tests for the /api/reports endpoints using example_gramps."""
 
 import unittest

--- a/tests/test_endpoints/test_reports.py
+++ b/tests/test_endpoints/test_reports.py
@@ -1,0 +1,166 @@
+"""Tests for the /api/reports endpoints using example_gramps."""
+
+import unittest
+from mimetypes import types_map
+
+from jsonschema import RefResolver, validate
+
+from . import API_SCHEMA, get_test_client
+
+
+class TestReports(unittest.TestCase):
+    """Test cases for the /api/reports endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_reports_endpoint(self):
+        """Test response for reports listing."""
+        # check valid response
+        result = self.client.get("/api/reports/")
+        self.assertEqual(result.status_code, 200)
+        self.assertIsInstance(result.json, type([]))
+        # check response conforms to schema
+        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
+        for report in result.json:
+            validate(
+                instance=report,
+                schema=API_SCHEMA["definitions"]["Report"],
+                resolver=resolver,
+            )
+        # check bad query parm response
+        result = self.client.get("/api/reports/?test=1")
+        self.assertEqual(result.status_code, 422)
+
+
+class TestReport(unittest.TestCase):
+    """Test cases for the /api/reports/{report_id} endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_reports_report_id_endpoint(self):
+        """Test response for a specific report."""
+        # check response for invalid report
+        result = self.client.get("/api/reports/no_real_report")
+        self.assertEqual(result.status_code, 404)
+        # check response for valid report
+        result = self.client.get("/api/reports/ancestor_report")
+        self.assertEqual(result.status_code, 200)
+        self.assertIsInstance(result.json, type({}))
+        # check response conforms to schema
+        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
+        validate(
+            instance=result.json,
+            schema=API_SCHEMA["definitions"]["Report"],
+            resolver=resolver,
+        )
+        # check bad query parm response
+        result = self.client.get("/api/reports/ancestor_report?test=1")
+        self.assertEqual(result.status_code, 422)
+
+
+class TestReportFile(unittest.TestCase):
+    """Test cases for the /api/reports/{report_id}/file endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_reports_report_id_file_endpoint(self):
+        """Test response for a fetching a specific report."""
+        # check response for invalid report
+        result = self.client.get("/api/reports/no_real_report/file")
+        self.assertEqual(result.status_code, 404)
+        # check response for valid report
+        result = self.client.get("/api/reports/ancestor_report/file")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.mimetype, types_map[".pdf"])
+        # check bad query parm response
+        result = self.client.get("/api/reports/ancestor_report/file?test=1")
+        self.assertEqual(result.status_code, 422)
+
+    def test_reports_report_id_file_options_parm(self):
+        """Test options query parameter parsing and validation."""
+        # check options parm json parsing error response
+        result = self.client.get("/api/reports/ancestor_report/file?options={1: 2}")
+        self.assertEqual(result.status_code, 400)
+        # check invalid options parm response
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"one_three": "four_two"}'
+        )
+        self.assertEqual(result.status_code, 422)
+        # check a valid options parm response
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"papero": "0"}'
+        )
+        self.assertEqual(result.status_code, 200)
+        # check reponses for some valid options parms but with bad values as we validate
+        # the values against the options_help data as best we can
+        # - a true/false option
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"incl_private": "Baloney"}'
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"incl_private": true}'
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"incl_private": "True"}'
+        )
+        self.assertEqual(result.status_code, 200)
+        # - a number option
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"maxgen": 2}'
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"maxgen": "2"}'
+        )
+        self.assertEqual(result.status_code, 200)
+        # - a list selection option
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"papero": "5"}'
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"papero": 0}'
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"papero": "0"}'
+        )
+        self.assertEqual(result.status_code, 200)
+        # check output file option is rejected as invalid in this context
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"of": "/tmp/junk.dat"}'
+        )
+        self.assertEqual(result.status_code, 422)
+        # check different output format accepted and processed properly
+        result = self.client.get(
+            '/api/reports/ancestor_report/file?options={"off": "rtf"}'
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.mimetype, types_map[".rtf"])
+
+    def test_reports_report_id_file_each_one(self):
+        """Test one of each available report."""
+        # some reports have unidentified mandatory options with no defaults
+        test_options = {
+            "familylines_graph": '?options={"gidlist": "I0044"}',
+            "place_report": '?options={"places": "P0863"}',
+        }
+        result_set = self.client.get("/api/reports/")
+        bad_reports = []
+        for report in result_set.json:
+            options = test_options.get(report["id"]) or ""
+            result = self.client.get("/api/reports/" + report["id"] + "/file" + options)
+            if result.status_code != 200:
+                bad_reports.append(report["id"])
+        self.assertEqual(bad_reports, [])


### PR DESCRIPTION
@DavidMStraub @Nick-Hall this is a work in progress that takes a first shot at adding the `/api/reports` endpoint. 

`/api/reports` returns the list of available reports and all their attributes and options, `/api/reports/{report}` does so for a specific report, and then `/api/reports/{report}/file` generates one.  

The web ones are filtered out and not returned at this time. I suppose one could write code to tar or zip up the directory and pass that down to the client but not sure it is really needed with a Web front end like David is building.

The report options are passed in using `options={}` query parm.  All options are passed in as strings and converted later.  So an example would be like this:

`
http://127.0.0.1:5000/api/reports/det_descendant_report/file?options={"gen":"5","incphotos":"True","off":"rtf"}`

I added some code to try to validate the options passed in against the available report options to verify the request is valid. I also set it up so it defaults to `pdf` if the `off` option is not provided. The file is generated temporarily on disk, read into the buffer to send to the client, and then deleted.

If you guys have a chance and can look it over and let me know if you see any problems, things that could be done a better way, etc as well as additional functionality I may be missing that you think is needed I'd appreciate it. I'll work on apischema updates and unit tests for it next. Thanks!