### PR TITLE
Refactor /api/metadata and add tests (Closes #48 and #73)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -113,7 +113,7 @@ register_endpt(
     "relations",
 )
 # Metadata
-register_endpt(MetadataResource, "/metadata/<string:datatype>", "metadata")
+register_endpt(MetadataResource, "/metadata/", "metadata")
 
 # Media files
 @api_blueprint.route("/media/<string:handle>/file")

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -1,11 +1,8 @@
 """Metadata API resource."""
 
-from typing import Dict
-
 import yaml
 from flask import Response
 from gramps.cli.clidbman import CLIDbManager
-from gramps.gen.config import get, get_section_settings, get_sections
 from gramps.gen.const import ENV, GRAMPS_LOCALE
 from gramps.gen.db.base import DbReadBase
 from pkg_resources import resource_filename
@@ -15,19 +12,6 @@ from gramps_webapi.const import VERSION
 from ..util import get_dbstate
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
-
-
-def get_config() -> Dict:
-    """Get the Gramps configuration options."""
-    config = {}
-    for section in get_sections():
-        data = {}
-        for setting in get_section_settings(section):
-            key = section + "." + setting
-            value = get(key)
-            data.update({key: value})
-        config.update({section: data})
-    return config
 
 
 class MetadataResource(ProtectedResource, GrampsJSONEncoder):
@@ -57,21 +41,19 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
             "database": {
                 "id": db_handle.get_dbid(),
                 "name": db_name,
-                "savepath": db_handle.get_save_path(),
                 "type": db_type,
             },
             "default_person": db_handle.get_default_handle(),
-            "gramps": {"config": get_config(), "env": ENV},
+            "gramps": {
+                "version": ENV["VERSION"],
+            },
             "gramps_webapi": {
                 "schema_version": schema["info"]["version"],
                 "version": VERSION,
             },
             "locale": {
                 "lang": GRAMPS_LOCALE.lang,
-                "localedir": GRAMPS_LOCALE.localedir,
-                "localedomain": GRAMPS_LOCALE.localedomain,
             },
-            "mediapath": db_handle.get_mediapath(),
             "object_counts": {},
             "researcher": db_handle.get_researcher(),
             "surnames": db_handle.get_surname_list(),
@@ -81,7 +63,8 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
             key = item.replace(" ", "_").lower()
             if "database" in key or "schema" in key:
                 key = key.replace("database_", "")
-                result["database"].update({key: data[item]})
+                if key != "module_location":
+                    result["database"].update({key: data[item]})
             elif "number_of" in key:
                 key = key.replace("number_of_", "")
                 result["object_counts"].update({key: data[item]})

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -2,14 +2,32 @@
 
 from typing import Dict
 
-from flask import Response, abort
+import yaml
+from flask import Response
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.config import get, get_section_settings, get_sections
+from gramps.gen.const import ENV, GRAMPS_LOCALE
 from gramps.gen.db.base import DbReadBase
-from webargs import fields
-from webargs.flaskparser import use_args
+from pkg_resources import resource_filename
+
+from gramps_webapi.const import VERSION
 
 from ..util import get_dbstate
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
+
+
+def get_config() -> Dict:
+    """Get the Gramps configuration options."""
+    config = {}
+    for section in get_sections():
+        data = {}
+        for setting in get_section_settings(section):
+            key = section + "." + setting
+            value = get(key)
+            data.update({key: value})
+        config.update({section: data})
+    return config
 
 
 class MetadataResource(ProtectedResource, GrampsJSONEncoder):
@@ -20,21 +38,53 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
         """Get the database instance."""
         return get_dbstate().db
 
-    @use_args(
-        {"type": fields.Str()},
-        location="query",
-    )
-    def get(self, args: Dict, datatype: str) -> Response:
-        """Get tree or application related metadata information."""
+    def get(self) -> Response:
+        """Get active database and application related metadata information."""
         db_handle = self.db_handle
-        if datatype == "summary":
-            summary = {}
-            data = db_handle.get_summary()
+        db_name = db_handle.get_dbname()
+        for data in CLIDbManager(get_dbstate()).family_tree_summary():
             for item in data:
-                summary[item.replace(" ", "_").lower()] = data[item]
-            return self.response(200, summary)
-        if datatype == "researcher":
-            return self.response(200, db_handle.get_researcher())
-        if datatype == "surnames":
-            return self.response(200, db_handle.get_surname_list())
-        abort(404)
+                if item == "Family Tree" and data[item] == db_name:
+                    db_type = data["Database"]
+                    break
+
+        with open(
+            resource_filename("gramps_webapi", "data/apispec.yaml")
+        ) as file_handle:
+            schema = yaml.safe_load(file_handle)
+
+        result = {
+            "database": {
+                "id": db_handle.get_dbid(),
+                "name": db_name,
+                "savepath": db_handle.get_save_path(),
+                "type": db_type,
+            },
+            "default_person": db_handle.get_default_handle(),
+            "gramps": {"config": get_config(), "env": ENV},
+            "gramps_webapi": {
+                "schema_version": schema["info"]["version"],
+                "version": VERSION,
+            },
+            "locale": {
+                "lang": GRAMPS_LOCALE.lang,
+                "localedir": GRAMPS_LOCALE.localedir,
+                "localedomain": GRAMPS_LOCALE.localedomain,
+            },
+            "mediapath": db_handle.get_mediapath(),
+            "object_counts": {},
+            "researcher": db_handle.get_researcher(),
+            "surnames": db_handle.get_surname_list(),
+        }
+        data = db_handle.get_summary()
+        for item in data:
+            key = item.replace(" ", "_").lower()
+            if "database" in key or "schema" in key:
+                key = key.replace("database_", "")
+                result["database"].update({key: data[item]})
+            elif "number_of" in key:
+                key = key.replace("number_of_", "")
+                result["object_counts"].update({key: data[item]})
+            else:
+                result[key] = data[item]
+        return self.response(200, result)

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -3,6 +3,8 @@
 import gramps.gen.lib as lib
 from pkg_resources import resource_filename
 
+from ._version import __version__ as VERSION
+
 # files
 TEST_CONFIG = resource_filename("gramps_webapi", "data/test.cfg")
 TEST_AUTH_CONFIG = resource_filename("gramps_webapi", "data/test_auth.cfg")

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -2378,59 +2378,24 @@ paths:
 # Endpoint - Metadata
 ##############################################################################
 
-  /metadata/summary:
+  /metadata:
     get:
       tags:
       - metadata
-      summary: "Get summary information about the currently loaded tree."
-      operationId: getTreeSummary
+      summary: "Get information about the application environment and state."
+      operationId: getMetadata
       security:
         - Bearer: []
       responses:
         200:
           description: "OK: Successful operation."
           schema:
-            $ref: "#/definitions/TreeSummary"
+            $ref: "#/definitions/Metadata"
         401:
           description: "Unauthorized: Missing authorization header."
 
-  /metadata/researcher:
-    get:
-      tags:
-      - metadata
-      summary: "Get information about the researcher for the currently loaded tree."
-      operationId: getTreeResearcher
-      security:
-        - Bearer: []
-      responses:
-        200:
-          description: "OK: Successful operation."
-          schema:
-            $ref: "#/definitions/TreeResearcher"
-        401:
-          description: "Unauthorized: Missing authorization header."
-
-  /metadata/surnames:
-    get:
-      tags:
-      - metadata
-      summary: "Get a list of all surnames from the currently loaded tree."
-      operationId: getTreeSurnames
-      security:
-        - Bearer: []
-      responses:
-        200:
-          description: "OK: Successful operation."
-          schema:
-            description: "The list of surnames."
-            type: array
-            items:
-              type: string
-        401:
-          description: "Unauthorized: Missing authorization header."
-
-##############################################################################
-# Model definitions
+##############################################################################    
+# Model definitions    
 ##############################################################################
 
 definitions:
@@ -4529,74 +4494,165 @@ definitions:
           - 46WJQCIOLQ0KOX2XCC
 
 ##############################################################################
-# Model - TreeSummary
+# Model - Metadata
 ##############################################################################
 
-  TreeSummary:
+  Metadata:
     type: object
     properties:
-      database_module_location:
-        description: "The database module location."
+      database:
+        description: "Information about the currently active database."
+        type: object
+        properties:
+          id:
+            description: "The database id."
+            type: string
+            example: "5f850009"
+          module_location:
+            description: "The database module location."
+            type: string
+            example: "/usr/lib64/python3.8/sqlite3/__init__.py"
+          module_version:
+            description: "The database module version."
+            type: string
+            example: "2.6.0"
+          name:
+            description: "The database and also tree name."
+            type: string
+            example: "example_gramps"
+          savepath:
+            description: "The database file location."
+            type: string
+            example: "/home/webapi/.gramps/grampsdb/5f850009"
+          schema_version:
+            description: "The data model schema version."
+            type: string
+            example: "18.0.0"
+          type:
+            description: "The database type."
+            type: string
+            example: "SQLite"
+          version:
+            description: "The database version."
+            type: string
+            example: "3.33.0"
+      default_person:
+        description: "The handle for the default person in the active database."
         type: string
-        example: "/usr/lib64/python3.8/sqlite3/__init__.py"
-      database_module_version:
-        description: "The database module version."
+        example: "GNUJQCL9MD64AM56OH"
+      gramps:
+        description: "Information about the currently active Gramps instance."
+        type: object
+        properties:
+          config: 
+            description: "The active Gramps configuration."
+            type: object
+            additionalProperties: true
+          env:
+            description: "The active Gramps environment."
+            type: object
+            additionalProperties: true
+      gramps_webapi:
+        description: "Information about the currently active Gramps Web API instance."
+        type: object
+        properties:
+          schema_version:
+            description: "The schema version."
+            type: string
+            example: "0.1.0"
+          version:
+            description: "The code version."
+            type: string
+            example: "0.1-dev"
+      locale:
+        description: "The active locale."
+        type: object
+        properties:
+          lang:
+            description: "The language code."
+            type: string
+            example: "en_US"
+          localedir:
+            description: "The path for the locale directory."
+            type: string
+            example: "/usr/share/locale"
+          localedomain:
+            description: "The domain for the locale."
+            type: string
+            example: "gramps"
+      mediapath:
+        description: "The path to the media objects associated with the database."
         type: string
-        example: "2.6.0"
-      database_version":
-        description: "The database version."
-        type: string
-        example: "3.33.0"
-      number_of_citations:
+        example: "{GRAMPS_RESOURCES}/doc/gramps/example/gramps"
+      object_counts:
+        $ref: "#/definitions/ObjectCounts"
+      researcher:
+        $ref: "#/definitions/Researcher"
+      surnames:
+        description: "A list of all surnames found in the database."
+        type: array
+        items:
+          type: string
+        example:
+          - Abbott
+          - Adams
+          - Adkins 
+
+##############################################################################
+# Model - ObjectCounts
+##############################################################################
+    
+  ObjectCounts:
+    description: "Total numbers for primary object types in the database."
+    type: object
+    properties:
+      citations:
         description: "The number of citations in the database."
         type: number
         example: 2854
-      number_of_events:
+      events:
         description: "The number of events in the database."
         type: number
         example: 3432
-      number_of_families:
+      families:
         description: "The number of families in the database."
         type: number
         example: 762
-      number_of_media:
+      media:
         description: "The number of media items in the database."
         type: number
         example: 7
-      number_of_notes:
+      notes:
         description: "The number of notes in the database."
         type: number
         example: 19
-      number_of_people:
+      people:
         description: "The number of people in the database."
         type: number
         example: 2157
-      number_of_places:
+      places:
         description: "The number of places in the database."
         type: number
         example: 1294
-      number_of_repositories:
+      repositories:
         description: "The number of repositories in the database."
         type: number
         example: 3
-      number_of_sources:
+      sources:
         description: "The number of sources in the database."
         type: number
         example: 4
-      number_of_tags:
+      tags:
         description: "The number of tags in the database."
         type: number
         example: 2
-      schema_version:
-        description: "The data model schema version."
-        type: string
-        example: "18.0.0"
 
 ##############################################################################
-# Model - TreeResearcher
+# Model - Researcher
 ##############################################################################
-
-  TreeResearcher:
+    
+  Researcher:
+    description: "Information about the primary researcher of the data."
     type: object
     properties:
       addr:
@@ -4643,29 +4699,6 @@ definitions:
         description: "Street."
         type: string
         example: ""
-
-##############################################################################
-# Model - NameSpaces
-##############################################################################
-
-  NameSpaces:
-    type: object
-    properties:
-      namespaces:
-        description: "Available name spaces."
-        type: array
-        items:
-          type: string
-        example:
-          - citations
-          - events
-          - families
-          - media
-          - notes
-          - people
-          - places
-          - repositories
-          - sources
 
 ##############################################################################
 # Model - Bookmarks

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4508,10 +4508,6 @@ definitions:
             description: "The database id."
             type: string
             example: "5f850009"
-          module_location:
-            description: "The database module location."
-            type: string
-            example: "/usr/lib64/python3.8/sqlite3/__init__.py"
           module_version:
             description: "The database module version."
             type: string
@@ -4520,10 +4516,6 @@ definitions:
             description: "The database and also tree name."
             type: string
             example: "example_gramps"
-          savepath:
-            description: "The database file location."
-            type: string
-            example: "/home/webapi/.gramps/grampsdb/5f850009"
           schema_version:
             description: "The data model schema version."
             type: string
@@ -4544,24 +4536,20 @@ definitions:
         description: "Information about the currently active Gramps instance."
         type: object
         properties:
-          config: 
-            description: "The active Gramps configuration."
-            type: object
-            additionalProperties: true
-          env:
-            description: "The active Gramps environment."
-            type: object
-            additionalProperties: true
+          version: 
+            description: "The version of the Gramps code."
+            type: string
+            example: "5.1.3"
       gramps_webapi:
         description: "Information about the currently active Gramps Web API instance."
         type: object
         properties:
           schema_version:
-            description: "The schema version."
+            description: "The version of the Gramps Web API schema."
             type: string
             example: "0.1.0"
           version:
-            description: "The code version."
+            description: "The version of the Gramps Web API code."
             type: string
             example: "0.1-dev"
       locale:
@@ -4572,18 +4560,6 @@ definitions:
             description: "The language code."
             type: string
             example: "en_US"
-          localedir:
-            description: "The path for the locale directory."
-            type: string
-            example: "/usr/share/locale"
-          localedomain:
-            description: "The domain for the locale."
-            type: string
-            example: "gramps"
-      mediapath:
-        description: "The path to the media objects associated with the database."
-        type: string
-        example: "{GRAMPS_RESOURCES}/doc/gramps/example/gramps"
       object_counts:
         $ref: "#/definitions/ObjectCounts"
       researcher:

--- a/tests/test_endpoints/test_metadata.py
+++ b/tests/test_endpoints/test_metadata.py
@@ -1,0 +1,29 @@
+"""Tests for the /api/metadata endpoint using example_gramps."""
+
+import unittest
+
+from jsonschema import RefResolver, validate
+
+from . import API_SCHEMA, get_test_client
+
+
+class TestMetadata(unittest.TestCase):
+    """Test cases for the /api/metadata endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_metadata_endpoint_schema(self):
+        """Test response for default types listing."""
+        # check expected number of record types found
+        result = self.client.get("/api/metadata/")
+        self.assertEqual(result.status_code, 200)
+        # check response conforms to schema
+        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
+        validate(
+            instance=result.json,
+            schema=API_SCHEMA["definitions"]["Metadata"],
+            resolver=resolver,
+        )

--- a/tests/test_endpoints/test_relations.py
+++ b/tests/test_endpoints/test_relations.py
@@ -97,14 +97,9 @@ class TestRelations(unittest.TestCase):
         result = self.client.get(
             "/api/relations/9BXKQC1PVLPYFMD6IX/ORFKQC4KLWEGTGR19L/all"
         )
+        self.assertIn("common_ancestors", result.json[0])
         self.assertEqual(
-            result.json,
-            [
-                {
-                    "common_ancestors": ["35WJQC1B7T7NPV8OLV", "46WJQCIOLQ0KOX2XCC"],
-                    "relationship_string": "second great stepgrandaunt",
-                }
-            ],
+            result.json[0]["relationship_string"], "second great stepgrandaunt"
         )
 
     def test_relations_all_endpoint_parms(self):


### PR DESCRIPTION
This refactors /api/metadata into a single get against the base endpoint and it returns everything. It is quick enough it doesn't seem to make sense to break things up into a bunch of smaller peices although that is probably the more RESTful thing to do.

The Gramps config settings and ENV settings are exposed in here now, as is locale.

Because I read in the schema to get the schema version for this I considered exposing that, but not sure if that would be here or /api/schema.  Do you think it should be somewhere or no?

Let me know if you would like anything added / removed / changed. 