### PR TITLE
Use localized string for event type in profile

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -81,7 +81,7 @@ def get_sex_profile(person: Person) -> str:
 def get_event_profile_for_object(db_handle: DbReadBase, event: Event) -> Dict:
     """Get event profile given an Event."""
     return {
-        "type": event.type.xml_str(),
+        "type": str(event.type),
         "date": dd.display(event.date),
         "place": pd.display_event(db_handle, event),
     }


### PR DESCRIPTION
A one-line PR: while using the un-localized event type names in `/events`, using `event.type.xml_str()` is the correct thing to do (as we discussed [here]), I realized it makes less sense for `profile`: here the date string is anyway localized and the whole point of the profile is to allow apps to display lists without having to do a lot of transformation. So I think it would be better to have the event type localized in the event profile dict. This is achieved by simply using `str(event.type)` instead.