### PR TITLE
WIP: Implement full-text search engine (fixes #74)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -50,6 +50,7 @@ from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
 from .resources.reports import ReportFileResource, ReportResource, ReportsResource
 from .resources.repositories import RepositoriesResource, RepositoryResource
+from .resources.search import SearchResource
 from .resources.sources import SourceResource, SourcesResource
 from .resources.tags import TagResource, TagsResource
 from .resources.token import TokenRefreshResource, TokenResource
@@ -137,14 +138,10 @@ register_endpt(TranslationResource, "/translations/<string:language>", "translat
 register_endpt(TranslationsResource, "/translations/", "translations")
 # Relations
 register_endpt(
-    RelationResource,
-    "/relations/<string:handle1>/<string:handle2>",
-    "relation",
+    RelationResource, "/relations/<string:handle1>/<string:handle2>", "relation",
 )
 register_endpt(
-    RelationsResource,
-    "/relations/<string:handle1>/<string:handle2>/all",
-    "relations",
+    RelationsResource, "/relations/<string:handle1>/<string:handle2>/all", "relations",
 )
 # Reports
 register_endpt(ReportFileResource, "/reports/<string:report_id>/file", "report-file")
@@ -160,6 +157,8 @@ register_endpt(ExportersResource, "/exporters/", "exporters")
 register_endpt(MetadataResource, "/metadata/", "metadata")
 # User
 register_endpt(UserChangePasswordResource, "/user/password/change", "change_password")
+# Search
+register_endpt(SearchResource, "/search/", "search")
 
 # Media files
 @api_blueprint.route("/media/<string:handle>/file")

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -10,10 +10,16 @@ from . import ProtectedResource
 class SearchResource(ProtectedResource):
     """Fulltext search resource."""
 
-    @use_args({"q": fields.Str(required=True)}, location="query")
+    @use_args(
+        {
+            "query": fields.Str(required=True),
+            "page": fields.Int(missing=1, required=False),
+            "pagesize": fields.Int(missing=10, required=False),
+        },
+        location="query",
+    )
     def get(self, args):
         """Get search result."""
-        if not args["q"]:
-            abort(400)
-        result = current_app.config["SEARCH_INDEXER"].search(args["q"])
+        searcher = current_app.config["SEARCH_INDEXER"]
+        result = searcher.search(args["query"], args["page"], args["pagesize"])
         return jsonify(result)

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -1,0 +1,19 @@
+"""Full-text search endpoint."""
+
+from flask import abort, current_app, jsonify
+from webargs import fields
+from webargs.flaskparser import use_args
+
+from . import ProtectedResource
+
+
+class SearchResource(ProtectedResource):
+    """Fulltext search resource."""
+
+    @use_args({"q": fields.Str(required=True)}, location="query")
+    def get(self, args):
+        """Get search result."""
+        if not args["q"]:
+            abort(400)
+        result = current_app.config["SEARCH_INDEXER"].search(args["q"])
+        return jsonify(result)

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -1,3 +1,23 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 """Full-text search endpoint."""
 
 from flask import current_app

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -70,9 +70,14 @@ class SearchIndexer:
                 )
 
     @staticmethod
-    def format_hit(hit: Hit):
+    def format_hit(hit: Hit) -> Dict[str, Any]:
         """Format a search hit."""
-        return (hit["class_name"], hit["handle"])
+        return {
+            "handle": hit["handle"],
+            "object_type": hit["class_name"],
+            "rank": hit.rank,
+            "score": hit.score,
+        }
 
     def search(self, query: str, extend: bool = False):
         """Search the index."""

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -1,0 +1,76 @@
+"""Full-text search utilities."""
+
+from pathlib import Path
+from typing import Generator, Tuple
+
+from gramps.gen.db.base import DbReadBase
+from whoosh import index
+from whoosh.fields import ID, TEXT, Schema
+from whoosh.qparser import QueryParser
+
+from ..const import PRIMARY_GRAMPS_OBJECTS
+from ..types import FilenameOrPath, Handle
+
+
+def object_to_string(obj):
+    """Create a string from a Gramps object's textual pieces."""
+    strings = obj.get_text_data_list()
+    for child_obj in obj.get_text_data_child_list():
+        if hasattr(child_obj, "get_text_data_list"):
+            strings += child_obj.get_text_data_list()
+    # discard duplicate strings but keep order
+    strings = dict.fromkeys(strings)
+    return " ".join(strings)
+
+
+def iter_obj_strings(
+    db_handle: DbReadBase,
+) -> Generator[Tuple[str, Handle, str], None, None]:
+    """Iterate over object strings in the whole database."""
+    for class_name in PRIMARY_GRAMPS_OBJECTS:
+        query_method = db_handle.method("get_%s_from_handle", class_name)
+        iter_method = db_handle.method("iter_%s_handles", class_name)
+        for handle in iter_method():
+            obj = query_method(handle)
+            obj_string = object_to_string(obj)
+            if obj_string:
+                yield class_name, obj.handle, obj_string
+
+
+class SearchIndexer:
+    """Full-text search indexer."""
+
+    SCHEMA = Schema(class_name=ID(stored=True), handle=ID(stored=True), text=TEXT)
+
+    def __init__(self, index_dir=FilenameOrPath):
+        """Initialize given an index dir path."""
+        self.index_dir = Path(index_dir)
+        self.index_dir.mkdir(exist_ok=True)
+        self.query_parser = QueryParser("text", schema=self.SCHEMA)
+
+    @property
+    def index(self):
+        """Return the index; create if doesn't exist."""
+        index_dir = str(self.index_dir)
+        if not index.exists_in(index_dir):
+            return index.create_in(index_dir, self.SCHEMA)
+        return index.open_dir(index_dir)
+
+    def reindex_full(self, db_handle: DbReadBase):
+        """Reindex the whole database."""
+        with self.index.writer() as writer:
+            for class_name, handle, obj_string in iter_obj_strings(db_handle):
+                writer.add_document(
+                    class_name=class_name.lower(), handle=handle, text=obj_string
+                )
+
+    def search(self, query: str, extend: bool = False):
+        """Search the index."""
+        handles = []
+        parsed_query = self.query_parser.parse(query)
+        with self.index.searcher() as searcher:
+            results = searcher.search(parsed_query)
+            handles = [(res["class_name"], res["handle"]) for res in results]
+        # discard duplicate tuples but keep order
+        handles = list(dict.fromkeys(handles))
+        return handles

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -1,5 +1,6 @@
 """Full-text search utilities."""
 
+from collections import OrderedDict
 from pathlib import Path
 from typing import Generator, Tuple
 
@@ -19,7 +20,7 @@ def object_to_string(obj):
         if hasattr(child_obj, "get_text_data_list"):
             strings += child_obj.get_text_data_list()
     # discard duplicate strings but keep order
-    strings = dict.fromkeys(strings)
+    strings = OrderedDict.fromkeys(strings)
     return " ".join(strings)
 
 
@@ -73,5 +74,5 @@ class SearchIndexer:
             results = searcher.search(parsed_query)
             handles = [(res["class_name"], res["handle"]) for res in results]
         # discard duplicate tuples but keep order
-        handles = list(dict.fromkeys(handles))
+        handles = list(OrderedDict.fromkeys(handles))
         return handles

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -1,3 +1,23 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 """Full-text search utilities."""
 
 from collections import OrderedDict

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -40,7 +40,9 @@ def iter_obj_strings(
 class SearchIndexer:
     """Full-text search indexer."""
 
-    SCHEMA = Schema(class_name=ID(stored=True), handle=ID(stored=True), text=TEXT)
+    SCHEMA = Schema(
+        class_name=ID(stored=True), handle=ID(stored=True), text=TEXT(stored=True)
+    )
 
     def __init__(self, index_dir=FilenameOrPath):
         """Initialize given an index dir path."""

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -27,6 +27,7 @@ class DefaultConfig(object):
     """Default configuration object."""
 
     PROPAGATE_EXCEPTIONS = True
+    SEARCH_INDEX_DIR = "indexdir"
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -68,6 +68,8 @@ tags:
   description: Access to family tree exporters.
 - name: metadata
   description: Access to tree and application metadata.
+- name: search
+  description: Search for objects
 
 ##############################################################################
 # Endpoint definitions
@@ -166,7 +168,7 @@ paths:
           description: "Unauthorized: Missing authorization header."
         422:
           description: "Unprocessable Entity: Invalid token."
-    
+
 ##############################################################################
 # Endpoint - People
 ##############################################################################
@@ -466,7 +468,7 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
-            age | Returns age at time of a personal event    
+            age | Returns age at time of a personal event
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
@@ -552,7 +554,7 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
-            age | Returns age at time of a personal event    
+            age | Returns age at time of a personal event
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
@@ -846,7 +848,7 @@ paths:
           description: "Unauthorized: Missing authorization header."
         404:
           description: "Not Found: Event not found."
-    
+
 ##############################################################################
 # Endpoint - Places
 ##############################################################################
@@ -1863,7 +1865,7 @@ paths:
           description: "Unauthorized: Missing authorization header."
         404:
           description: "Not Found: Media item not found."
-    
+
 ##############################################################################
 # Endpoint - Notes
 ##############################################################################
@@ -2473,10 +2475,10 @@ paths:
               media:
                 $ref: "#/definitions/NamespaceFilters"
               notes:
-                $ref: "#/definitions/NamespaceFilters"                            
+                $ref: "#/definitions/NamespaceFilters"
         401:
           description: "Unauthorized: Missing authorization header."
-    
+
   /filters/{namespace}:
     get:
       tags:
@@ -2754,7 +2756,7 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
-##############################################################################    
+##############################################################################
 # Endpoint - Reports
 ##############################################################################
 
@@ -2824,7 +2826,7 @@ paths:
           specific to a given report. A few reports do not have defaults for all options and require
           some be specified in order to run properly.
 
-    
+
           If no _off_ option for report output file format is provided then pdf will be used as a fallback.
           The _of_ option for output file is ignored by this endpoint as the report file is ephemeral.
       responses:
@@ -2874,7 +2876,7 @@ paths:
       responses:
         200:
           description: "OK: Successful operation."
-          schema:    
+          schema:
             $ref: "#/definitions/Exporter"
         401:
           description: "Unauthorized: Missing authorization header."
@@ -3041,7 +3043,7 @@ paths:
             type: file
         401:
           description: "Unauthorized: Missing authorization header."
-    
+
         404:
           description: "Not Found: Exporter not found."
         422:
@@ -3067,8 +3069,51 @@ paths:
         401:
           description: "Unauthorized: Missing authorization header."
 
-##############################################################################    
-# Model definitions    
+
+##############################################################################
+# Endpoint - Search
+##############################################################################
+
+  /search:
+    get:
+      tags:
+      - search
+      summary: "Perform a full-text search on multiple objects."
+      operationId: getSearch
+      security:
+        - Bearer: []
+      parameters:
+      - name: query
+        in: query
+        required: true
+        type: string
+        description: "The search string."
+        example: "Anderson"
+      - name: page
+        in: query
+        required: false
+        type: integer
+        default: 1
+        description: "The page number of the search results to return."
+      - name: pagesize
+        in: query
+        required: false
+        type: integer
+        default: 10
+        description: "The number search results to return per page."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/SearchResults"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity"
+
+
+##############################################################################
+# Model definitions
 ##############################################################################
 
 definitions:
@@ -5108,7 +5153,7 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/FilterRuleDescription"
-    
+
 ##############################################################################
 # Model - Translations
 ##############################################################################
@@ -5219,7 +5264,7 @@ definitions:
         description: "Information about the currently active Gramps instance."
         type: object
         properties:
-          version: 
+          version:
             description: "The version of the Gramps code."
             type: string
             example: "5.1.3"
@@ -5267,12 +5312,12 @@ definitions:
         example:
           - Abbott
           - Adams
-          - Adkins 
+          - Adkins
 
 ##############################################################################
 # Model - ObjectCounts
 ##############################################################################
-    
+
   ObjectCounts:
     description: "Total numbers for primary object types in the database."
     type: object
@@ -5321,7 +5366,7 @@ definitions:
 ##############################################################################
 # Model - Researcher
 ##############################################################################
-    
+
   Researcher:
     description: "Information about the primary researcher of the data."
     type: object
@@ -5633,7 +5678,7 @@ definitions:
         type: string
         example: "exportxml"
 
-##############################################################################    
+##############################################################################
 # Model - Report
 ##############################################################################
 
@@ -5645,7 +5690,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - "Donald N. Allingham"
       authors_email:
         description: "Email addresses for report authors."
@@ -5674,8 +5719,8 @@ definitions:
         description: "Dictionary containing all of the report options with their defaults."
         type: object
         additionalProperties: true
-        example: 
-          papero: 0        
+        example:
+          papero: 0
       options_help:
         description: "Dictionary containing help information for all of the report options."
         type: object
@@ -5716,3 +5761,55 @@ definitions:
         - "0\t"
         - "1\t"
 
+
+##############################################################################
+# Model - SearchResults
+##############################################################################
+
+  SearchResults:
+    type: object
+    properties:
+      info:
+        description: "General information about the search results."
+        type: object
+        properties:
+          pagecount:
+            description: "Total number of pages in the search result."
+            type: integer
+            example: 2
+          pagesize:
+            description: "Page size of the search results."
+            type: integer
+            example: 2
+          pagenum:
+            description: "Number of currently displayed search result page."
+            type: integer
+            example: 1
+          offset:
+            description: "Offset of the first displayed serach hit."
+            type: integer
+            example: 0
+          runtime:
+            description: "Run time of the index search in seconds."
+            type: number
+            example: 0.0010769180007628165
+          total:
+            type: integer
+            example: 2
+      hits:
+        description: "The list of search hits."
+        type: array
+        items:
+          type: object
+          properties:
+            handle:
+              type: string
+              example: "e9027bf39c27be945fab9df8124"
+            object:
+              type: object
+            object_type:
+              type: string
+              example: person
+            score:
+              type: number
+              example: 5.522300827719273

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ REQUIREMENTS = [
     "pdf2image",
     "Pillow",
     "bleach",
+    "whoosh",
 ]
 
 EXTRA_REQUIREMENTS = ["pycairo", "PyGObject"]

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -63,6 +63,18 @@ class TestSearch(unittest.TestCase):
             [("note", "b39fe2e143d1e599450"), ("source", "b39fe3f390e30bd2b99")],
         )
 
+    def test_search_endpoint_2(self):
+        result = self.client.get("/api/search/?q=microfilm")
+        # NB, JSON turns the tuples into lists, obviously!
+        self.assertEqual(
+            result.json,
+            [["note", "b39fe2e143d1e599450"], ["source", "b39fe3f390e30bd2b99"]],
+        )
+
     def test_search_3(self):
         handles = self.search.search("LoremIpsumDolorSitAmet")
         self.assertEqual(handles, [])
+
+    def test_search_endpoint_3(self):
+        result = self.client.get("/api/search/?q=LoremIpsumDolorSitAmet")
+        self.assertEqual(result.json, [])

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -100,3 +100,10 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(result.json["info"]["pagecount"], 0)
         self.assertEqual(result.json["info"]["pagenum"], 0)
         self.assertEqual(result.json["info"]["offset"], 0)
+
+    def test_object(self):
+        result = self.client.get("/api/search/?query=I0044")
+        self.assertEqual(len(result.json["hits"]), 1)
+        hit = result.json["hits"][0]
+        self.assertIn("object", hit)
+        self.assertEqual(hit["object"]["gramps_id"], "I0044")

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -19,7 +19,9 @@ class TestSearch(unittest.TestCase):
         cls.index_dir = tempfile.mkdtemp()
         cls.dbmgr = cls.client.application.config["DB_MANAGER"]
         cls.search = SearchIndexer(cls.index_dir)
-        cls.search.reindex_full(cls.dbmgr.get_db().db)
+        db = cls.dbmgr.get_db().db
+        cls.search.reindex_full(db)
+        db.close()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -30,18 +30,19 @@ class TestSearch(unittest.TestCase):
 
     def test_reindex(self):
         # test if reindexing again leads to doubled results
-        hits = self.search.search("I0044")
-        self.assertEqual(len(hits), 1)
+        result = self.search.search("I0044", page=1, pagesize=10)
+        self.assertEqual(len(result["hits"]), 1)
         db = self.__class__.dbmgr.get_db().db
         self.__class__.search.reindex_full(db)
         db.close()
-        hits = self.search.search("I0044")
-        self.assertEqual(len(hits), 1)
+        result = self.search.search("I0044", page=1, pagesize=10)
+        self.assertEqual(len(result["hits"]), 1)
 
     def test_search_1(self):
-        hits = self.search.search("Abigail")
+        result = self.search.search("Abigail", page=1, pagesize=10)
+        hits = result["hits"]
         self.assertEqual(
-            set([(hit["object_type"], hit["handle"]) for hit in hits]),
+            {(hit["object_type"], hit["handle"]) for hit in hits},
             {
                 ("person", "1QTJQCP5QMT2X7YJDK"),
                 ("person", "APWKQCI6YXAXBLC33I"),
@@ -56,9 +57,14 @@ class TestSearch(unittest.TestCase):
             },
         )
 
+    def test_search_endpoint_1(self):
+        # missing query parameter
+        result = self.client.get("/api/search/")
+        self.assertEqual(result.status_code, 422)
+
     def test_search_endpoint_2(self):
-        result = self.client.get("/api/search/?q=microfilm")
-        hits = result.json
+        result = self.client.get("/api/search/?query=microfilm")
+        hits = result.json["hits"]
         self.assertEqual(
             [hit["handle"] for hit in hits],
             ["b39fe2e143d1e599450", "b39fe3f390e30bd2b99"],
@@ -68,5 +74,29 @@ class TestSearch(unittest.TestCase):
         self.assertIsInstance(hits[0]["score"], float)
 
     def test_search_endpoint_3(self):
-        result = self.client.get("/api/search/?q=LoremIpsumDolorSitAmet")
-        self.assertEqual(result.json, [])
+        result = self.client.get("/api/search/?query=microfilm&page=1&pagesize=1")
+        hits = result.json["hits"]
+        self.assertEqual(
+            [hit["handle"] for hit in hits], ["b39fe2e143d1e599450"],
+        )
+        self.assertEqual(result.json["info"]["total"], 2)
+        self.assertEqual(result.json["info"]["pagecount"], 2)
+        self.assertEqual(result.json["info"]["pagenum"], 1)
+        self.assertEqual(result.json["info"]["offset"], 0)
+        result = self.client.get("/api/search/?query=microfilm&page=2&pagesize=1")
+        hits = result.json["hits"]
+        self.assertEqual(result.json["info"]["total"], 2)
+        self.assertEqual(result.json["info"]["pagecount"], 2)
+        self.assertEqual(result.json["info"]["pagenum"], 2)
+        self.assertEqual(result.json["info"]["offset"], 1)
+        self.assertEqual(
+            [hit["handle"] for hit in hits], ["b39fe3f390e30bd2b99"],
+        )
+
+    def test_search_endpoint_4(self):
+        result = self.client.get("/api/search/?query=LoremIpsumDolorSitAmet")
+        self.assertEqual(result.json["hits"], [])
+        self.assertEqual(result.json["info"]["total"], 0)
+        self.assertEqual(result.json["info"]["pagecount"], 0)
+        self.assertEqual(result.json["info"]["pagenum"], 0)
+        self.assertEqual(result.json["info"]["offset"], 0)

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -28,6 +28,16 @@ class TestSearch(unittest.TestCase):
         """Remove the temp directory."""
         shutil.rmtree(cls.index_dir)
 
+    def test_reindex(self):
+        # test if reindexing again leads to doubled results
+        handles = self.search.search("I0044")
+        self.assertEqual(handles, [("person", "GNUJQCL9MD64AM56OH")])
+        db = self.__class__.dbmgr.get_db().db
+        self.__class__.search.reindex_full(db)
+        db.close()
+        handles = self.search.search("I0044")
+        self.assertEqual(handles, [("person", "GNUJQCL9MD64AM56OH")])
+
     def test_search_1(self):
         handles = self.search.search("Abigail")
         self.assertEqual(

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -1,3 +1,23 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn, David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 """Test full-text search."""
 
 import shutil

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -41,8 +41,8 @@ class TestSearch(unittest.TestCase):
     def test_search_1(self):
         handles = self.search.search("Abigail")
         self.assertEqual(
-            handles,
-            [
+            set(handles),
+            {
                 ("person", "1QTJQCP5QMT2X7YJDK"),
                 ("person", "APWKQCI6YXAXBLC33I"),
                 ("person", "H4UJQCQI05USCJ93RO"),
@@ -53,7 +53,7 @@ class TestSearch(unittest.TestCase):
                 ("event", "a5af0ec600f56496ec9"),
                 ("event", "a5af0ec602419320d6a"),
                 ("event", "a5af0ec60365264cf35"),
-            ],
+            },
         )
 
     def test_search_2(self):

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -39,22 +39,11 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(len(result["hits"]), 1)
 
     def test_search_1(self):
-        result = self.search.search("Abigail", page=1, pagesize=10)
+        result = self.search.search("Abigail", page=1, pagesize=2)
         hits = result["hits"]
         self.assertEqual(
             {(hit["object_type"], hit["handle"]) for hit in hits},
-            {
-                ("person", "1QTJQCP5QMT2X7YJDK"),
-                ("person", "APWKQCI6YXAXBLC33I"),
-                ("person", "H4UJQCQI05USCJ93RO"),
-                ("event", "a5af0ec3be8255006e4"),
-                ("event", "a5af0ec5165620023c2"),
-                ("event", "a5af0ec51752bb3933a"),
-                ("event", "a5af0ec51864cfd234f"),
-                ("event", "a5af0ec600f56496ec9"),
-                ("event", "a5af0ec602419320d6a"),
-                ("event", "a5af0ec60365264cf35"),
-            },
+            {("person", "1QTJQCP5QMT2X7YJDK"), ("person", "APWKQCI6YXAXBLC33I"),},
         )
 
     def test_search_endpoint_1(self):

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -1,0 +1,56 @@
+"""Test full-text search."""
+
+import shutil
+import tempfile
+import unittest
+
+from tests.test_endpoints import get_test_client
+
+from gramps_webapi.api.search import SearchIndexer
+
+
+class TestSearch(unittest.TestCase):
+    """Test cases for full-text search."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+        cls.index_dir = tempfile.mkdtemp()
+        cls.dbmgr = cls.client.application.config["DB_MANAGER"]
+        cls.search = SearchIndexer(cls.index_dir)
+        cls.search.reindex_full(cls.dbmgr.get_db().db)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the temp directory."""
+        shutil.rmtree(cls.index_dir)
+
+    def test_search_1(self):
+        handles = self.search.search("Abigail")
+        self.assertEqual(
+            handles,
+            [
+                ("person", "1QTJQCP5QMT2X7YJDK"),
+                ("person", "APWKQCI6YXAXBLC33I"),
+                ("person", "H4UJQCQI05USCJ93RO"),
+                ("event", "a5af0ec3be8255006e4"),
+                ("event", "a5af0ec5165620023c2"),
+                ("event", "a5af0ec51752bb3933a"),
+                ("event", "a5af0ec51864cfd234f"),
+                ("event", "a5af0ec600f56496ec9"),
+                ("event", "a5af0ec602419320d6a"),
+                ("event", "a5af0ec60365264cf35"),
+            ],
+        )
+
+    def test_search_2(self):
+        handles = self.search.search("microfilm")
+        self.assertEqual(
+            handles,
+            [("note", "b39fe2e143d1e599450"), ("source", "b39fe3f390e30bd2b99")],
+        )
+
+    def test_search_3(self):
+        handles = self.search.search("LoremIpsumDolorSitAmet")
+        self.assertEqual(handles, [])


### PR DESCRIPTION
As discussed in #74, I added a search indexer using `whoosh` combined with Gramps's `get_text_data_list` and `get_text_data_child_list` methods. It iterates over all objects in the DB and indexes a text string that is the concatenation of all text data and the text data of children (in the case of person objects, those are names and attributes, for instance). It works really well and is very fast! You can look at the unit tests to see how it works.

To do list:

- [x] Add endpoint 
- [x] Add paging to endpoint
- [x] Implement `extend` (which will replace the handle list by an object list)
- ~Implement incremental reindexing (checking the last modified date of the index and the DB and then fetching only objects that have changed)~
- [x] Trigger the full indexing (at application startup if it doesn't exist?)
- ~Trigger the incremental reindexing (before every query?)~
- [x] Add config option for index dir