### PR TITLE
Use JSON (not form) for token/user endpoints

### DIFF
--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -21,7 +21,7 @@ class TokenResource(Resource):
 
     @limiter.limit("1/second")
     @use_args(
-        {"username": fields.Str(), "password": fields.Str()}, location="form",
+        {"username": fields.Str(), "password": fields.Str()}, location="json",
     )
     def post(self, args):
         """Post username and password to fetch a token."""

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -16,7 +16,7 @@ class UserChangePasswordResource(ProtectedResource):
             "old_password": fields.Str(required=True),
             "new_password": fields.Str(required=True),
         },
-        location="form",
+        location="json",
     )
     def post(self, args):
         """Post new password."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ class TestPerson(unittest.TestCase):
         assert rv.json["death_ref_index"] == -1
 
     def test_token_endpoint(self):
-        rv = self.client.post("/api/login/", data={})
+        rv = self.client.post("/api/login/", json={})
         assert rv.status_code == 200
         assert rv.json == {"access_token": 1, "refresh_token": 1}
 

--- a/tests/test_endpoints/test_token.py
+++ b/tests/test_endpoints/test_token.py
@@ -15,7 +15,7 @@ class TestToken(unittest.TestCase):
 
     def test_token_endpoint(self):
         """Test login endpoint."""
-        result = self.client.post("/api/login/", data={})
+        result = self.client.post("/api/login/")
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json, {"access_token": 1, "refresh_token": 1})
 

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -38,59 +38,59 @@ class TestUser(unittest.TestCase):
     def test_change_password_no_token(self):
         rv = self.client.post(
             "/api/user/password/change",
-            data={"old_password": "123", "new_password": "456"},
+            json={"old_password": "123", "new_password": "456"},
         )
         assert rv.status_code == 401
 
     def test_change_password_wrong_old_pw(self):
         rv = self.client.post(
-            "/api/login/", data={"username": "user", "password": "123"}
+            "/api/login/", json={"username": "user", "password": "123"}
         )
         assert rv.status_code == 200
         token = rv.json["access_token"]
         rv = self.client.post(
             "/api/user/password/change",
             headers={"Authorization": "Bearer {}".format(token)},
-            data={"old_password": "012", "new_password": "456"},
+            json={"old_password": "012", "new_password": "456"},
         )
         assert rv.status_code == 403
 
     def test_change_password(self):
         rv = self.client.post(
-            "/api/login/", data={"username": "user", "password": "123"}
+            "/api/login/", json={"username": "user", "password": "123"}
         )
         assert rv.status_code == 200
         token = rv.json["access_token"]
         rv = self.client.post(
             "/api/user/password/change",
             headers={"Authorization": "Bearer {}".format(token)},
-            data={"old_password": "123", "new_password": "456"},
+            json={"old_password": "123", "new_password": "456"},
         )
         assert rv.status_code == 201
         rv = self.client.post(
-            "/api/login/", data={"username": "user", "password": "123"}
+            "/api/login/", json={"username": "user", "password": "123"}
         )
         assert rv.status_code == 403
         rv = self.client.post(
-            "/api/login/", data={"username": "user", "password": "456"}
+            "/api/login/", json={"username": "user", "password": "456"}
         )
         assert rv.status_code == 200
 
     def test_change_password_twice(self):
         rv = self.client.post(
-            "/api/login/", data={"username": "user", "password": "123"}
+            "/api/login/", json={"username": "user", "password": "123"}
         )
         assert rv.status_code == 200
         token = rv.json["access_token"]
         rv = self.client.post(
             "/api/user/password/change",
             headers={"Authorization": "Bearer {}".format(token)},
-            data={"old_password": "123", "new_password": "456"},
+            json={"old_password": "123", "new_password": "456"},
         )
         assert rv.status_code == 201
         rv = self.client.post(
             "/api/user/password/change",
             headers={"Authorization": "Bearer {}".format(token)},
-            data={"old_password": "123", "new_password": "456"},
+            json={"old_password": "123", "new_password": "456"},
         )
         assert rv.status_code == 403

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -53,11 +53,12 @@ class TestPerson(unittest.TestCase):
         # no authorization header!
         assert rv.status_code == 401
         # fetch a token and try again
-        rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
+        rv = self.client.post(
+            "/api/login/", json={"username": "user", "password": "123"}
+        )
         token = rv.json["access_token"]
         rv = self.client.get(
-            "/api/people/",
-            headers={"Authorization": "Bearer {}".format(token)},
+            "/api/people/", headers={"Authorization": "Bearer {}".format(token)},
         )
         assert rv.status_code == 200
         it = rv.json[0]
@@ -65,7 +66,9 @@ class TestPerson(unittest.TestCase):
         # no authorization header!
         assert rv.status_code == 401
         # fetch a token and try again
-        rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
+        rv = self.client.post(
+            "/api/login/", json={"username": "user", "password": "123"}
+        )
         token = rv.json["access_token"]
         rv = self.client.get(
             "/api/people/" + it["handle"] + "?profile",
@@ -83,28 +86,34 @@ class TestPerson(unittest.TestCase):
         assert rv.json["death_ref_index"] == -1
 
     def test_token_endpoint(self):
-        rv = self.client.post("/api/login/", data={})
+        rv = self.client.post("/api/login/", json={})
         # no username or password provided
         assert rv.status_code == 401
-        rv = self.client.post("/api/login/", data={"username": "user", "password": 234})
+        rv = self.client.post(
+            "/api/login/", json={"username": "user", "password": "234"}
+        )
         # wrong pw
         assert rv.status_code == 403
         rv = self.client.post(
-            "/api/login/", data={"username": "admin", "password": 123}
+            "/api/login/", json={"username": "admin", "password": "123"}
         )
         # wrong user
         assert rv.status_code == 403
-        rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
+        rv = self.client.post(
+            "/api/login/", json={"username": "user", "password": "123"}
+        )
         assert rv.status_code == 200
         assert "refresh_token" in rv.json
         assert "access_token" in rv.json
 
     def test_refresh_token_endpoint(self):
-        rv = self.client.post("/api/refresh/", data={})
+        rv = self.client.post("/api/refresh/", json={})
         # no authorization header!
         assert rv.status_code == 401
         # fetch a token and try again
-        rv = self.client.post("/api/login/", data={"username": "user", "password": 123})
+        rv = self.client.post(
+            "/api/login/", json={"username": "user", "password": "123"}
+        )
         refresh_token = rv.json["refresh_token"]
         access_token = rv.json["access_token"]
         # incorrectly send access token instead of refresh token!


### PR DESCRIPTION
This changes the token and password endpoints to expect a JSON payload in POST rather than a form. I had used a form accidentally originally, but this doesn't make sense as we use JSON for the rest of the API. Adapted the unit tests accordingly.