### PR TITLE
Update filters, metadata, apispec.yaml

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -34,7 +34,7 @@ from .resources.bookmarks import BookmarkResource, BookmarksResource
 from .resources.citations import CitationResource, CitationsResource
 from .resources.events import EventResource, EventsResource
 from .resources.families import FamiliesResource, FamilyResource
-from .resources.filters import FilterResource, FiltersResource
+from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.media import MediaObjectResource, MediaObjectsResource
 from .resources.metadata import MetadataResource
 from .resources.name_formats import NameFormatsResource
@@ -121,7 +121,8 @@ register_endpt(BookmarkResource, "/bookmarks/<string:namespace>", "bookmark")
 register_endpt(BookmarksResource, "/bookmarks/", "bookmarks")
 # Filters
 register_endpt(FilterResource, "/filters/<string:namespace>/<string:name>", "filter")
-register_endpt(FiltersResource, "/filters/<string:namespace>", "filters")
+register_endpt(FiltersResource, "/filters/<string:namespace>", "filters-namespace")
+register_endpt(FiltersResources, "/filters/", "filters")
 # Translations
 register_endpt(TranslationResource, "/translations/<string:language>", "translation")
 register_endpt(TranslationsResource, "/translations/", "translations")

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -184,6 +184,23 @@ class CustomFilterSchema(FilterSchema):
     )
 
 
+class FiltersResources(ProtectedResource, GrampsJSONEncoder):
+    """Filters resources."""
+
+    @use_args(
+        {},
+        location="query",
+    )
+    def get(self, args: Dict[str, str]) -> Response:
+        """Get available custom filters and rules."""
+        results = {}
+        for namespace in GRAMPS_NAMESPACES:
+            rule_list = get_filter_rules(args, GRAMPS_NAMESPACES[namespace])
+            filter_list = get_custom_filters(args, GRAMPS_NAMESPACES[namespace])
+            results[namespace] = {"filters": filter_list, "rules": rule_list}
+        return self.response(200, results)
+
+
 class FiltersResource(ProtectedResource, GrampsJSONEncoder):
     """Filters resource."""
 

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -132,6 +132,37 @@ paths:
           description: "Unprocessable Entity: Invalid token."
 
 ##############################################################################
+# Endpoint - User
+##############################################################################
+
+  /user/password/change:
+    post:
+      tags:
+      - authentication
+      summary: "Change a user password."
+      operationId: changeUserPassword
+      security:
+        - Bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        type: string
+        description: "The JWT refresh token."
+      - name: passwords
+        in: body
+        required: true
+        schema:
+          $ref: "#/definitions/PasswordChange"
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+    
+##############################################################################
 # Endpoint - People
 ##############################################################################
 
@@ -5186,3 +5217,22 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Media"
+
+##############################################################################
+# Model - PasswordChange
+##############################################################################
+
+  PasswordChange:
+    type: object
+    required:
+      - old_password
+      - new_password
+    properties:
+      old_password:
+        description: "The old password."
+        type: string
+        example: "abc123"
+      new_password:
+        description: "The new password."
+        type: string
+        example: "321cba"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -191,6 +191,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -221,6 +222,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the person should be included in the response or not."
       - name: extend
         in: query
@@ -275,6 +277,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -305,6 +308,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the person should be included in the response or not."
       - name: extend
         in: query
@@ -398,6 +402,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -427,6 +432,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the family should be included in the response or not."
       - name: extend
         in: query
@@ -480,6 +486,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -509,6 +516,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the family should be included in the response or not."
       - name: extend
         in: query
@@ -601,6 +609,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -629,6 +638,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the event should be included in the response or not."
       - name: extend
         in: query
@@ -679,6 +689,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -707,6 +718,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the event should be included in the response or not."
       - name: extend
         in: query
@@ -796,6 +808,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -811,6 +824,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the place should be included in the response or not."
       - name: extend
         in: query
@@ -860,6 +874,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -875,6 +890,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the place should be included in the response or not."
       - name: extend
         in: query
@@ -963,6 +979,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -978,6 +995,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the citation should be included in the response or not."
       - name: extend
         in: query
@@ -1027,6 +1045,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1042,6 +1061,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the citation should be included in the response or not."
       - name: extend
         in: query
@@ -1130,6 +1150,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1145,6 +1166,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the source should be included in the response or not."
       - name: extend
         in: query
@@ -1194,6 +1216,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1209,6 +1232,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the source should be included in the response or not."
       - name: extend
         in: query
@@ -1297,6 +1321,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1312,6 +1337,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the repository should be included in the response or not."
       - name: extend
         in: query
@@ -1359,6 +1385,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1374,6 +1401,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the repository should be included in the response or not."
       - name: extend
         in: query
@@ -1460,6 +1488,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1475,6 +1504,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the media item should be included in the response or not."
       - name: extend
         in: query
@@ -1523,6 +1553,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1538,6 +1569,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the media item should be included in the response or not."
       - name: extend
         in: query
@@ -1565,6 +1597,174 @@ paths:
         404:
           description: "Not Found: Media item not found."
 
+  /media/{handle}/file:
+    get:
+      tags:
+      - media
+      summary: "Download a specific media item."
+      operationId: getMediaItemFile
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        minLength: 8
+        description: "The unique identifier for a media item."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+
+  /media/{handle}/thumbnail/{size}:
+    get:
+      tags:
+      - media
+      summary: "Download the thumbnail for a specific media item."
+      operationId: getMediaItemThumbnail
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        minLength: 8
+        description: "The unique identifier for a media item."
+      - name: size
+        in: path
+        required: true
+        type: integer
+        description: "The size of the thumbnail to generate."
+      - name: square
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether image should be cropped to a centered square."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+
+  /media/{handle}/cropped/{x1}/{y1}/{x2}/{y2}:
+    get:
+      tags:
+      - media
+      summary: "Download the cropped version of a specific media item."
+      operationId: getMediaItemCropped
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        minLength: 8
+        description: "The unique identifier for a media item."
+      - name: x1
+        in: path
+        required: true
+        type: integer
+        description: "The x1 coordinate to use for cropping."
+      - name: y1
+        in: path
+        required: true
+        type: integer
+        description: "The y1 coordinate to use for cropping."
+      - name: x2
+        in: path
+        required: true
+        type: integer
+        description: "The x2 coordinate to use for cropping."
+      - name: y2
+        in: path
+        required: true
+        type: integer
+        description: "The y2 coordinate to use for cropping."
+      - name: square
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether image should be cropped to a centered square."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+
+  /media/{handle}/cropped/{x1}/{y1}/{x2}/{y2}/thumbnail/{size}:
+    get:
+      tags:
+      - media
+      summary: "Download the thumbnail of a cropped version of a specific media item."
+      operationId: getMediaItemCroppedThumbnail
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        minLength: 8
+        description: "The unique identifier for a media item."
+      - name: x1
+        in: path
+        required: true
+        type: integer
+        description: "The x1 coordinate to use for cropping."
+      - name: y1
+        in: path
+        required: true
+        type: integer
+        description: "The y1 coordinate to use for cropping."
+      - name: x2
+        in: path
+        required: true
+        type: integer
+        description: "The x2 coordinate to use for cropping."
+      - name: y2
+        in: path
+        required: true
+        type: integer
+        description: "The y2 coordinate to use for cropping."
+      - name: size
+        in: path
+        required: true
+        type: integer
+        description: "The size of the thumbnail to generate."
+      - name: square
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether image should be cropped to a centered square."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+    
 ##############################################################################
 # Endpoint - Notes
 ##############################################################################
@@ -1634,6 +1834,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1649,6 +1850,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the note should be included in the response or not."
       - name: extend
         in: query
@@ -1704,6 +1906,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1719,6 +1922,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether handles to objects referring to the note should be included in the response or not."
       - name: extend
         in: query
@@ -1761,6 +1965,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -1803,6 +2008,7 @@ paths:
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates whether keys with empty values should be stripped out of the response or not."
       - name: keys
         in: query
@@ -2137,6 +2343,41 @@ paths:
 # Endpoint - Filters
 ##############################################################################
 
+  /filters:
+    get:
+      tags:
+      - filters
+      summary: "Get all custom filters and rules for all namespaces."
+      operationId: getAllFilters
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: object
+            properties:
+              people:
+                $ref: "#/definitions/NamespaceFilters"
+              families:
+                $ref: "#/definitions/NamespaceFilters"
+              events:
+                $ref: "#/definitions/NamespaceFilters"
+              places:
+                $ref: "#/definitions/NamespaceFilters"
+              citations:
+                $ref: "#/definitions/NamespaceFilters"
+              sources:
+                $ref: "#/definitions/NamespaceFilters"
+              repositories:
+                $ref: "#/definitions/NamespaceFilters"
+              media:
+                $ref: "#/definitions/NamespaceFilters"
+              notes:
+                $ref: "#/definitions/NamespaceFilters"                            
+        401:
+          description: "Unauthorized: Missing authorization header."
+    
   /filters/{namespace}:
     get:
       tags:
@@ -2165,16 +2406,7 @@ paths:
         200:
           description: "OK: Successful operation."
           schema:
-            type: object
-            properties:
-              filters:
-                type: array
-                items:
-                  $ref: "#/definitions/CustomFilter"
-              rules:
-                type: array
-                items:
-                  $ref: "#/definitions/FilterRuleDescription"
+            $ref: "#/definitions/NamespaceFilters"
         401:
           description: "Unauthorized: Missing authorization header."
         404:
@@ -2370,11 +2602,13 @@ paths:
         in: query
         required: false
         type: integer
+        default: 15
         description: "Depth for the search, default is 15 generations."
       - name: locale
         in: query
         required: false
         type: boolean
+        default: false
         description: "Indicates to return relationship string in current locale."
       responses:
         200:
@@ -2407,6 +2641,7 @@ paths:
         in: query
         required: false
         type: integer
+        default: false
         description: "Depth for the search, default is 15 generations."
       responses:
         200:
@@ -4463,6 +4698,22 @@ definitions:
           $ref: "#/definitions/FilterRule"
 
 ##############################################################################
+# Model - NamespaceFilters
+##############################################################################
+
+  NamespaceFilters:
+    type: object
+    properties:
+      filters:
+        type: array
+        items:
+          $ref: "#/definitions/CustomFilter"
+      rules:
+        type: array
+        items:
+          $ref: "#/definitions/FilterRuleDescription"
+    
+##############################################################################
 # Model - Translations
 ##############################################################################
 
@@ -4604,8 +4855,8 @@ definitions:
             description: "The language code."
             type: string
             example: "en"
-          locale:
-            description: "The locale code."
+          lang:
+            description: "The effective language locale."
             type: string
             example: "en_US"
       object_counts:

--- a/tests/test_endpoints/test_filters.py
+++ b/tests/test_endpoints/test_filters.py
@@ -29,6 +29,29 @@ from tests.test_endpoints import API_SCHEMA, get_test_client
 from tests.test_endpoints.runners import run_test_filters_endpoint_namespace
 
 
+class TestAllFilters(unittest.TestCase):
+    """Test cases for the /api/filters endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_filters_endpoint_schema(self):
+        """Test against the filters schema."""
+        resolver = RefResolver(base_uri="", referrer=API_SCHEMA, store={"": API_SCHEMA})
+        result = self.client.get("/api/filters/")
+        for namespace in GRAMPS_NAMESPACES:
+            # check present in response
+            self.assertIn(namespace, result.json)
+            # check against schema
+            validate(
+                instance=result.json[namespace],
+                schema=API_SCHEMA["definitions"]["NamespaceFilters"],
+                resolver=resolver,
+            )
+
+
 class TestFilters(unittest.TestCase):
     """Test cases for the /api/filters/{namespace} endpoint."""
 


### PR DESCRIPTION
@DavidMStraub this tweaks /api/metadata again, adds a base /api/filters that returns all the namespaces to be consistent with the other endpoints that return full collections, and contains some updates for the apispec.yaml including the various image endpoints.