### PR TITLE
Add age/span support; sort, offset & limit support; and locale support for profile and relationship calculator (Closes #32, #56, #88)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -32,7 +32,7 @@ from .file import LocalFileHandler
 from .resources.base import Resource
 from .resources.bookmarks import BookmarkResource, BookmarksResource
 from .resources.citations import CitationResource, CitationsResource
-from .resources.events import EventResource, EventsResource
+from .resources.events import EventResource, EventSpanResource, EventsResource
 from .resources.exporters import (
     ExporterFileResource,
     ExporterResource,
@@ -81,6 +81,9 @@ register_endpt(PeopleResource, "/people/", "people")
 register_endpt(FamilyResource, "/families/<string:handle>", "family")
 register_endpt(FamiliesResource, "/families/", "families")
 # Events
+register_endpt(
+    EventSpanResource, "/events/<string:handle1>/span/<string:handle2>", "event-span"
+)
 register_endpt(EventResource, "/events/<string:handle>", "event")
 register_endpt(EventsResource, "/events/", "events")
 # Places

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -132,6 +132,8 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "filter": fields.Str(validate=validate.Length(min=1)),
             "rules": fields.Str(validate=validate.Length(min=1)),
+            "offset": fields.Integer(missing=0, validate=validate.Range(min=0)),
+            "limit": fields.Integer(missing=0, validate=validate.Range(min=1)),
             "formats": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
@@ -158,6 +160,8 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             handles = apply_filter(
                 self.db_handle, args, self.gramps_class_name, handles
             )
+        if args["limit"] > 0:
+            handles = handles[args["offset"] : args["offset"] + args["limit"]]
 
         query_method = self.db_handle.method(
             "get_%s_from_handle", self.gramps_class_name

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -35,7 +35,7 @@ from . import ProtectedResource, Resource
 from .emit import GrampsJSONEncoder
 from .filters import apply_filter
 from .sort import sort_objects
-from .util import get_backlinks, get_extended_attributes
+from .util import get_backlinks, get_extended_attributes, get_soundex
 
 
 class GrampsObjectResourceHelper(GrampsJSONEncoder):
@@ -50,6 +50,10 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
         """Get the full object with extended attributes and backlinks."""
         if args.get("backlinks"):
             obj.backlinks = get_backlinks(self.db_handle, obj.handle)
+        if args.get("soundex"):
+            if self.gramps_class_name not in ["Person", "Family"]:
+                abort(422)
+            obj.soundex = get_soundex(self.db_handle, obj, self.gramps_class_name)
         obj = self.object_extend(obj, args)
         return obj
 
@@ -106,6 +110,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
                 fields.Str(validate=validate.Length(min=1))
             ),
             "backlinks": fields.Boolean(missing=False),
+            "soundex": fields.Boolean(missing=False),
         },
         location="query",
     )
@@ -146,6 +151,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
                 fields.Str(validate=validate.Length(min=1))
             ),
             "backlinks": fields.Boolean(missing=False),
+            "soundex": fields.Boolean(missing=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -91,7 +91,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
-                    choices=["all", "self", "families", "events"]
+                    choices=["all", "self", "families", "events", "age", "span"]
                 ),
             ),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
@@ -125,7 +125,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
-                    choices=["all", "self", "families", "events"]
+                    choices=["all", "self", "families", "events", "age", "span"]
                 ),
             ),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),

--- a/gramps_webapi/api/resources/citations.py
+++ b/gramps_webapi/api/resources/citations.py
@@ -23,7 +23,9 @@
 
 from typing import Dict
 
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Citation
+from gramps.gen.utils.grampslocale import GrampsLocale
 
 from .base import (
     GrampsObjectProtectedResource,
@@ -38,7 +40,9 @@ class CitationResourceHelper(GrampsObjectResourceHelper):
 
     gramps_class_name = "Citation"
 
-    def object_extend(self, obj: Citation, args: Dict) -> Citation:
+    def object_extend(
+        self, obj: Citation, args: Dict, locale: GrampsLocale = glocale
+    ) -> Citation:
         """Extend citation attributes as needed."""
         if "extend" in args:
             db_handle = self.db_handle

--- a/gramps_webapi/api/resources/emit.py
+++ b/gramps_webapi/api/resources/emit.py
@@ -140,4 +140,7 @@ class GrampsJSONEncoder(JSONEncoder):
         if isinstance(obj, DbBookmarks):
             return self.api_filter(obj)
 
-        return JSONEncoder.default(self, obj)
+        try:
+            return JSONEncoder.default(self, obj)
+        except TypeError:
+            return None

--- a/gramps_webapi/api/resources/families.py
+++ b/gramps_webapi/api/resources/families.py
@@ -24,7 +24,9 @@
 from typing import Dict
 
 from flask import abort
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Family
+from gramps.gen.utils.grampslocale import GrampsLocale
 
 from .base import (
     GrampsObjectProtectedResource,
@@ -43,11 +45,15 @@ class FamilyResourceHelper(GrampsObjectResourceHelper):
 
     gramps_class_name = "Family"
 
-    def object_extend(self, obj: Family, args: Dict) -> Family:
+    def object_extend(
+        self, obj: Family, args: Dict, locale: GrampsLocale = glocale
+    ) -> Family:
         """Extend family attributes as needed."""
         db_handle = self.db_handle
         if "profile" in args:
-            obj.profile = get_family_profile_for_object(db_handle, obj, args["profile"])
+            obj.profile = get_family_profile_for_object(
+                db_handle, obj, args["profile"], locale=locale
+            )
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
             if "all" in args["extend"] or "father_handle" in args["extend"]:

--- a/gramps_webapi/api/resources/families.py
+++ b/gramps_webapi/api/resources/families.py
@@ -47,15 +47,7 @@ class FamilyResourceHelper(GrampsObjectResourceHelper):
         """Extend family attributes as needed."""
         db_handle = self.db_handle
         if "profile" in args:
-            if "families" in args["profile"]:
-                abort(422)
-            if "all" in args["profile"] or "events" in args["profile"]:
-                with_events = True
-            else:
-                with_events = False
-            obj.profile = get_family_profile_for_object(
-                db_handle, obj, with_events=with_events
-            )
+            obj.profile = get_family_profile_for_object(db_handle, obj, args["profile"])
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
             if "all" in args["extend"] or "father_handle" in args["extend"]:

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -132,13 +132,15 @@ def build_filter(filter_parms: Dict, namespace: str) -> GenericFilter:
     return filter_object
 
 
-def apply_filter(db_handle: DbReadBase, args: Dict, namespace: str) -> List[Handle]:
+def apply_filter(
+    db_handle: DbReadBase, args: Dict, namespace: str, handles: List = None
+) -> List[Handle]:
     """Apply an existing or dynamically defined filter."""
     filters.reload_custom_filters()
     if args.get("filter"):
         for filter_class in filters.CustomFilters.get_filters(namespace):
             if args["filter"] == filter_class.get_name():
-                return filter_class.apply(db_handle)
+                return filter_class.apply(db_handle, id_list=handles)
         abort(404)
 
     try:
@@ -149,7 +151,7 @@ def apply_filter(db_handle: DbReadBase, args: Dict, namespace: str) -> List[Hand
         abort(422)
 
     filter_object = build_filter(filter_parms, namespace)
-    return filter_object.apply(db_handle)
+    return filter_object.apply(db_handle, id_list=handles)
 
 
 class RuleSchema(Schema):

--- a/gramps_webapi/api/resources/notes.py
+++ b/gramps_webapi/api/resources/notes.py
@@ -23,7 +23,9 @@
 
 from typing import Dict
 
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Note
+from gramps.gen.utils.grampslocale import GrampsLocale
 
 from ..html import get_note_html
 from .base import (
@@ -42,7 +44,9 @@ class NoteResourceHelper(GrampsObjectResourceHelper):
     # supported formatted note formats (all lowercase!)
     FORMATS_SUPPORTED = ["html"]
 
-    def object_extend(self, obj: Note, args: Dict) -> Note:
+    def object_extend(
+        self, obj: Note, args: Dict, locale: GrampsLocale = glocale
+    ) -> Note:
         """Extend note attributes as needed."""
         if "formats" in args:
             formats_allowed = [

--- a/gramps_webapi/api/resources/people.py
+++ b/gramps_webapi/api/resources/people.py
@@ -23,7 +23,9 @@
 
 from typing import Dict
 
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Person
+from gramps.gen.utils.grampslocale import GrampsLocale
 
 from .base import (
     GrampsObjectProtectedResource,
@@ -42,11 +44,15 @@ class PersonResourceHelper(GrampsObjectResourceHelper):
 
     gramps_class_name = "Person"
 
-    def object_extend(self, obj: Person, args: Dict) -> Person:
+    def object_extend(
+        self, obj: Person, args: Dict, locale: GrampsLocale = glocale
+    ) -> Person:
         """Extend person attributes as needed."""
         db_handle = self.db_handle
         if "profile" in args:
-            obj.profile = get_person_profile_for_object(db_handle, obj, args["profile"])
+            obj.profile = get_person_profile_for_object(
+                db_handle, obj, args["profile"], locale=locale
+            )
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
             if "all" in args["extend"] or "families" in args["extend"]:

--- a/gramps_webapi/api/resources/people.py
+++ b/gramps_webapi/api/resources/people.py
@@ -46,17 +46,7 @@ class PersonResourceHelper(GrampsObjectResourceHelper):
         """Extend person attributes as needed."""
         db_handle = self.db_handle
         if "profile" in args:
-            if "all" in args["profile"] or "families" in args["profile"]:
-                with_family = True
-            else:
-                with_family = False
-            if "all" in args["profile"] or "events" in args["profile"]:
-                with_events = True
-            else:
-                with_events = False
-            obj.profile = get_person_profile_for_object(
-                db_handle, obj, with_family=with_family, with_events=with_events
-            )
+            obj.profile = get_person_profile_for_object(db_handle, obj, args["profile"])
         if "extend" in args:
             obj.extended = get_extended_attributes(db_handle, obj, args)
             if "all" in args["extend"] or "families" in args["extend"]:

--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -23,7 +23,6 @@
 from typing import Dict
 
 from flask import Response, abort
-from gramps.gen.const import GRAMPS_LOCALE
 from gramps.gen.relationship import get_relationship_calculator
 from webargs import fields, validate
 from webargs.flaskparser import use_args
@@ -56,10 +55,7 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
         if person2 == {}:
             abort(404)
 
-        locale = GRAMPS_LOCALE
-        if args["locale"] is not None:
-            locale = get_locale_for_language(args["locale"], default=True)
-
+        locale = get_locale_for_language(args["locale"], default=True)
         calc = get_relationship_calculator(reinit=True, clocale=locale)
         calc.set_depth(args["depth"])
 
@@ -95,10 +91,7 @@ class RelationsResource(ProtectedResource, GrampsJSONEncoder):
         if person2 == {}:
             abort(404)
 
-        locale = GRAMPS_LOCALE
-        if args["locale"] is not None:
-            locale = get_locale_for_language(args["locale"], default=True)
-
+        locale = get_locale_for_language(args["locale"], default=True)
         calc = get_relationship_calculator(reinit=True, clocale=locale)
         calc.set_depth(args["depth"])
 

--- a/gramps_webapi/api/resources/sort.py
+++ b/gramps_webapi/api/resources/sort.py
@@ -1,0 +1,302 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2000-2007  Donald N. Allingham
+# Copyright (C) 2020       Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Sorting support."""
+
+from flask import abort
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.display.name import displayer as _nd
+from gramps.gen.display.place import displayer as _pd
+from gramps.gen.lib import Date
+from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
+
+
+class Sort:
+    """Class for extracting sort keys."""
+
+    def __init__(self, database, namespace, locale=glocale):
+        """Initialize sort class."""
+        self.database = database
+        self.locale = locale
+        self.namespace = namespace
+        self.query_method = self.database.method("get_%s_from_handle", self.namespace)
+
+    # Generic object key methods
+
+    def by_id_key(self, handle):
+        """Compare by Gramps Id."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.gramps_id)
+
+    def by_change_key(self, handle):
+        """Compare by last change."""
+        obj = self.query_method(handle)
+        return obj.change
+
+    def by_private_key(self, handle):
+        """Compare based on private attribute."""
+        obj = self.query_method(handle)
+        return int(obj.private)
+
+    def by_date_key(self, handle):
+        """Compare by date."""
+        obj = self.query_method(handle)
+        return obj.get_date_object().get_sort_value()
+
+    def by_type_key(self, handle):
+        """Compare by type."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(str(obj.get_type()))
+
+    # Specific object key methods
+
+    def by_person_surname_key(self, handle):
+        """Compare by surname, if equal uses given name and suffix."""
+        obj = self.query_method(handle)
+        name = obj.get_primary_name()
+        fsn = name.get_surname()
+        ffn = name.get_first_name()
+        fsu = name.get_suffix()
+        return self.locale.sort_key(fsn + ffn + fsu)
+
+    def by_person_sorted_name_key(self, handle):
+        """Compare by displayed names."""
+        obj = self.query_method(handle)
+        name = _nd.sorted(obj)
+        return self.locale.sort_key(name)
+
+    def by_person_birthdate_key(self, handle):
+        """Compare by birth date, if equal sorts by name."""
+        obj = self.query_method(handle)
+        birth = get_birth_or_fallback(self.database, obj)
+        if birth:
+            date = birth.get_date_object()
+        else:
+            date = Date()
+        return "%08d" % date.get_sort_value() + str(self.by_person_surname_key(handle))
+
+    def by_person_deathdate_key(self, handle):
+        """Compare by death date, if equal sorts by name."""
+        obj = self.query_method(handle)
+        death = get_death_or_fallback(self.database, obj)
+        if death:
+            date = death.get_date_object()
+        else:
+            date = Date()
+        return "%08d" % date.get_sort_value() + str(self.by_person_surname_key(handle))
+
+    def by_person_gender_key(self, handle):
+        """Compare by gender."""
+        obj = self.query_method(handle)
+        return obj.gender
+
+    def by_family_surname_key(self, handle):
+        """Compare by family surname, if equal uses given and suffix."""
+        obj = self.query_method(handle)
+        if obj.father_handle is not None:
+            name = self.database.get_person_from_handle(obj.father_handle)
+        elif obj.mother_handle is not None:
+            name = self.database.get_person_from_handle(obj.mother_handle)
+        fsn = name.get_surname()
+        ffn = name.get_first_name()
+        fsu = name.get_suffix()
+        return self.locale.sort_key(fsn + ffn + fsu)
+
+    def by_family_type_key(self, handle):
+        """Compare by relationship type."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(str(obj.get_type()))
+
+    def by_event_place_key(self, handle):
+        """Compare by event place."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(_pd.display_event(self.database, obj))
+
+    def by_event_description_key(self, handle):
+        """Compare by event description."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.get_description())
+
+    def by_place_title_key(self, handle):
+        """Compare by place title."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(_pd.display(self.database, obj))
+
+    def by_place_latitude_key(self, handle):
+        """Compare by place latitude."""
+        obj = self.query_method(handle)
+        return obj.lat
+
+    def by_place_longitude_key(self, handle):
+        """Compare by place longitude."""
+        obj = self.query_method(handle)
+        return obj.long
+
+    def by_citation_confidence_key(self, handle):
+        """Compare by citation confidence."""
+        obj = self.query_method(handle)
+        return obj.confidence
+
+    def by_source_title_key(self, handle):
+        """Compare by source title."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.title)
+
+    def by_source_author_key(self, handle):
+        """Compare by source title."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.author)
+
+    def by_source_pubinfo_key(self, handle):
+        """Compare by source publication info."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.pubinfo)
+
+    def by_source_abbrev_key(self, handle):
+        """Compare by source abbreviation."""
+        obj = self.query_method(handle)
+        return obj.abbrev
+
+    def by_repository_name_key(self, handle):
+        """Compare by repository name."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.name)
+
+    def by_media_title_key(self, handle):
+        """Compare by media title."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.desc)
+
+    def by_media_path_key(self, handle):
+        """Compare by media path."""
+        obj = self.query_method(handle)
+        return obj.path
+
+    def by_media_mimetype_key(self, handle):
+        """Compare by media mime type."""
+        obj = self.query_method(handle)
+        return obj.mime
+
+    def by_note_text_key(self, handle):
+        """Compare by note text."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.text.string)
+
+    def by_tag_name_key(self, handle):
+        """Compare by tag name."""
+        obj = self.query_method(handle)
+        return self.locale.sort_key(obj.name)
+
+    def by_tag_color_key(self, handle):
+        """Compare by tag color."""
+        obj = self.query_method(handle)
+        return obj.color
+
+    def by_tag_priority_key(self, handle):
+        """Compare by tag priority."""
+        obj = self.query_method(handle)
+        return obj.priority
+
+
+def sort_objects(db_handle, gramps_class_name, handles, args, locale=glocale):
+    """Sort a given set of object handles."""
+    sort = Sort(db_handle, gramps_class_name, locale=locale)
+    lookup = {
+        "gramps_id": sort.by_id_key,
+        "change": sort.by_change_key,
+        "private": sort.by_private_key,
+    }
+    if gramps_class_name == "Person":
+        lookup.update(
+            {
+                "surname": sort.by_person_surname_key,
+                "name": sort.by_person_sorted_name_key,
+                "birth": sort.by_person_birthdate_key,
+                "death": sort.by_person_deathdate_key,
+                "gender": sort.by_person_gender_key,
+            }
+        )
+    elif gramps_class_name == "Family":
+        lookup.update(
+            {"name": sort.by_family_surname_key, "type": sort.by_family_type_key}
+        )
+    elif gramps_class_name == "Event":
+        lookup.update(
+            {
+                "date": sort.by_date_key,
+                "type": sort.by_type_key,
+                "description": sort.by_event_description_key,
+                "place": sort.by_event_place_key,
+            }
+        )
+    elif gramps_class_name == "Place":
+        lookup.update(
+            {
+                "title": sort.by_place_title_key,
+                "type": sort.by_type_key,
+                "latitude": sort.by_place_latitude_key,
+                "longitude": sort.by_place_longitude_key,
+            }
+        )
+    elif gramps_class_name == "Citation":
+        lookup.update(
+            {"date": sort.by_date_key, "confidence": sort.by_citation_confidence_key}
+        )
+    elif gramps_class_name == "Source":
+        lookup.update(
+            {
+                "title": sort.by_source_title_key,
+                "author": sort.by_source_author_key,
+                "pubinfo": sort.by_source_pubinfo_key,
+                "abbrev": sort.by_source_abbrev_key,
+            }
+        )
+    elif gramps_class_name == "Repository":
+        lookup.update({"name": sort.by_repository_name_key, "type": sort.by_type_key})
+    elif gramps_class_name == "Media":
+        lookup.update(
+            {
+                "title": sort.by_media_title_key,
+                "path": sort.by_media_path_key,
+                "mime": sort.by_media_mimetype_key,
+                "date": sort.by_date_key,
+            }
+        )
+    elif gramps_class_name == "Note":
+        lookup.update({"type": sort.by_type_key, "text": sort.by_note_text_key})
+    elif gramps_class_name == "Tag":
+        lookup = {
+            "change": sort.by_change_key,
+            "name": sort.by_tag_name_key,
+            "color": sort.by_tag_color_key,
+            "priority": sort.by_tag_priority_key,
+        }
+
+    for sort_key in args:
+        sort_key = sort_key.strip()
+        reverse = False
+        if sort_key[:1] == "-":
+            reverse = True
+            sort_key = sort_key[1:]
+        if sort_key not in lookup:
+            abort(422)
+        handles.sort(key=lambda x: lookup[sort_key](x), reverse=reverse)
+    return handles

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -30,6 +30,7 @@ from gramps.gen.display.place import PlaceDisplay
 from gramps.gen.errors import HandleError
 from gramps.gen.lib import Event, Family, Person, Place, Source, Span
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
+from gramps.gen.soundex import soundex
 from gramps.gen.utils.db import (
     get_birth_or_fallback,
     get_death_or_fallback,
@@ -362,3 +363,17 @@ def get_backlinks(db_handle: DbReadBase, handle: Handle) -> Dict[str, List[Handl
             backlinks[key] = []
         backlinks[key].append(target_handle)
     return backlinks
+
+
+def get_soundex(
+    db_handle: DbReadBase, obj: GrampsObject, gramps_class_name: str
+) -> str:
+    """Return soundex code."""
+    if gramps_class_name == "Family":
+        if obj.father_handle is not None:
+            person = db_handle.get_person_from_handle(obj.father_handle)
+        elif obj.mother_handle is not None:
+            person = db_handle.get_person_from_handle(obj.mother_handle)
+    else:
+        person = obj
+    return soundex(person.get_primary_name().get_surname())

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -49,12 +49,14 @@ def get_media_base_dir():
     return expand_media_path(db.get_mediapath(), db)
 
 
-def get_locale_for_language(language_code: str):
+def get_locale_for_language(language: str, default: bool = False) -> GrampsLocale:
     """Get GrampsLocale set to specified language."""
     catalog = GRAMPS_LOCALE.get_language_dict()
-    for language in catalog:
-        if catalog[language] == language_code:
-            return GrampsLocale(lang=language_code)
+    for entry in catalog:
+        if catalog[entry] == language:
+            return GrampsLocale(lang=language)
+    if default:
+        return GRAMPS_LOCALE
     return None
 
 

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -51,10 +51,11 @@ def get_media_base_dir():
 
 def get_locale_for_language(language: str, default: bool = False) -> GrampsLocale:
     """Get GrampsLocale set to specified language."""
-    catalog = GRAMPS_LOCALE.get_language_dict()
-    for entry in catalog:
-        if catalog[entry] == language:
-            return GrampsLocale(lang=language)
+    if language is not None:
+        catalog = GRAMPS_LOCALE.get_language_dict()
+        for entry in catalog:
+            if catalog[entry] == language:
+                return GrampsLocale(lang=language)
     if default:
         return GRAMPS_LOCALE
     return None

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -183,6 +183,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a person, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -403,6 +414,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a family, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -619,6 +641,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for an event, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -878,6 +911,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a place, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -1054,6 +1098,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a citation, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -1230,6 +1285,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a source, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -1406,6 +1472,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a repository, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -1578,6 +1655,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a media item, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -1920,6 +2008,17 @@ paths:
         required: false
         type: string
         description: "An alternate user managed identifier for a note, usually but not guaranteed to be unique."
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: filter
         in: query
         required: false
@@ -2103,6 +2202,17 @@ paths:
       security:
         - Bearer: []
       parameters:
+      - name: offset
+        in: query
+        required: false
+        type: integer
+        default: 0
+        description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: limit
+        in: query
+        required: false
+        type: integer
+        description: "The maximum number of items to be returned. By default all are returned."
       - name: strip
         in: query
         required: false

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -266,23 +266,17 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the person and their familial relationships in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For people the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            age | Returns age at time of a personal event
-            self | Returns name, sex, birth and death information and is an implied default when events or families specified
-            span | Returns elapsed time span from union that formed the family and familial events
-            events | Returns event list with name, date and location
-            families | Returns family information with parents, children, and key relationship between parents
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: backlinks
         in: query
         required: false
@@ -311,17 +305,23 @@ paths:
             primary_parent_family | The primary parent family record
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: soundex
-        in: query
-        required: false
-        type: boolean
-        default: false
-        description: "Indicates whether to include the soundex code for the surname or not."
-      - name: locale
+      - name: profile
         in: query
         required: false
         type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
+        description: >
+          Enables the return of summarized information about the person and their familial relationships in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For people the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            age | Returns age at time of a personal event
+            self | Returns name, sex, birth and death information and is an implied default when events or families specified
+            span | Returns elapsed time span from union that formed the family and familial events
+            events | Returns event list with name, date and location
+            families | Returns family information with parents, children, and key relationship between parents
       responses:
         200:
           description: "OK: Successful operation."
@@ -365,23 +365,17 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the person and their familial relationships in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For people the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            age | Returns age at time of a personal event
-            self | Returns name, sex, birth and death information and is an implied default when events or families specified
-            span | Returns elapsed time span from union that formed the family and familial events
-            events | Returns event list with name, date and location
-            families | Returns family information with parents, children, and key relationship between parents
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: backlinks
         in: query
         required: false
@@ -410,6 +404,23 @@ paths:
             primary_parent_family | The primary parent family record
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: profile
+        in: query
+        required: false
+        type: string
+        description: >
+          Enables the return of summarized information about the person and their familial relationships in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For people the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            age | Returns age at time of a personal event
+            self | Returns name, sex, birth and death information and is an implied default when events or families specified
+            span | Returns elapsed time span from union that formed the family and familial events
+            events | Returns event list with name, date and location
+            families | Returns family information with parents, children, and key relationship between parents
       responses:
         200:
           description: "OK: Successful operation."
@@ -518,22 +529,17 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the family in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For families the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            age | Returns age at time of a personal event    
-            self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
-            span | Returns elapsed time span from union that formed the family and familial events
-            events | Returns family event list with name, date and location
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: backlinks
         in: query
         required: false
@@ -561,17 +567,22 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: soundex
-        in: query
-        required: false
-        type: boolean
-        default: false
-        description: "Indicates whether to include the soundex code for the surname or not."
-      - name: locale
+      - name: profile
         in: query
         required: false
         type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
+        description: >
+          Enables the return of summarized information about the family in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For families the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            age | Returns age at time of a personal event    
+            self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
+            span | Returns elapsed time span from union that formed the family and familial events
+            events | Returns family event list with name, date and location
       responses:
         200:
           description: "OK: Successful operation."
@@ -615,22 +626,17 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the family in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For a family the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            age | Returns age at time of a personal event    
-            self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
-            span | Returns elapsed time span from union that formed the family and familial events
-            events | Returns family event list with name, date and location
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: backlinks
         in: query
         required: false
@@ -658,6 +664,22 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: profile
+        in: query
+        required: false
+        type: string
+        description: >
+          Enables the return of summarized information about the family in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For a family the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            age | Returns age at time of a personal event    
+            self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
+            span | Returns elapsed time span from union that formed the family and familial events
+            events | Returns family event list with name, date and location
       responses:
         200:
           description: "OK: Successful operation."
@@ -767,19 +789,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the event in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For events the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            events | Returns event name, date and location
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -804,11 +818,19 @@ paths:
             place | The place record for the event
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
+      - name: profile
         in: query
         required: false
         type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
+        description: >
+          Enables the return of summarized information about the event in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For events the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            events | Returns event name, date and location
       responses:
         200:
           description: "OK: Successful operation."
@@ -852,19 +874,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
-      - name: profile
+      - name: locale
         in: query
         required: false
         type: string
-        description: >
-          Enables the return of summarized information about the event in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
-
-
-          Accepts a comma delimited list of possible objects to be provided. For an event the possible objects are:
-            Object | Contents
-            ------ | --------
-            all | Returns all information below
-            events | Returns event name, date and location
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -889,6 +903,19 @@ paths:
             place | The place record for the event
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: profile
+        in: query
+        required: false
+        type: string
+        description: >
+          Enables the return of summarized information about the event in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For an event the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information below
+            events | Returns event name, date and location
       responses:
         200:
           description: "OK: Successful operation."
@@ -918,17 +945,17 @@ paths:
         required: true
         type: string
         description: "The unique identifier for the second event."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: as_age
         in: query
         required: false
         type: boolean
         default: true
         description: "Indicates whether to return result as an age or not."
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for the translated string if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: precision
         in: query
         required: false
@@ -1053,6 +1080,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -1076,11 +1108,6 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1254,6 +1281,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -1277,11 +1309,6 @@ paths:
             source | The source record cited from
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1457,6 +1484,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -1480,11 +1512,6 @@ paths:
             reporef_list | The list of referenced repository records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1658,6 +1685,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -1679,11 +1711,6 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1857,6 +1884,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -1879,11 +1911,6 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -2233,6 +2260,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       - name: backlinks
         in: query
         required: false
@@ -2253,11 +2285,6 @@ paths:
             all | Returns all possible records listed below
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
-      - name: locale
-        in: query
-        required: false
-        type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -2397,7 +2424,7 @@ paths:
         in: query
         required: false
         type: string
-        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -6,7 +6,7 @@ info:
 
     * The Gramps Web API project is hosted at https://github.com/gramps-project/web-api
 
-   
+
     * More about Gramps and the numerous features it provides for genealogists can be found at https://gramps-project.org
   version: "0.1.0"
   license:
@@ -249,7 +249,9 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
+            age | Returns age at time of a personal event
             self | Returns name, sex, birth and death information and is an implied default when events or families specified
+            span | Returns elapsed time span from union that formed the family and familial events
             events | Returns event list with name, date and location
             families | Returns family information with parents, children, and key relationship between parents
       - name: backlinks
@@ -335,7 +337,9 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
+            age | Returns age at time of a personal event
             self | Returns name, sex, birth and death information and is an implied default when events or families specified
+            span | Returns elapsed time span from union that formed the family and familial events
             events | Returns event list with name, date and location
             families | Returns family information with parents, children, and key relationship between parents
       - name: backlinks
@@ -460,7 +464,9 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
+            age | Returns age at time of a personal event    
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
+            span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
       - name: backlinks
         in: query
@@ -544,7 +550,9 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
+            age | Returns age at time of a personal event    
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
+            span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
       - name: backlinks
         in: query
@@ -2696,9 +2704,8 @@ paths:
       - name: locale
         in: query
         required: false
-        type: boolean
-        default: false
-        description: "Indicates to return relationship string in current locale."
+        type: string
+        description: "Specifies the locale for the translated string if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -2732,6 +2739,11 @@ paths:
         type: integer
         default: false
         description: "Depth for the search, default is 15 generations."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for the translated string if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -782,6 +782,61 @@ paths:
         404:
           description: "Not Found: Event not found."
 
+  /events/{handle1}/span/{handle2}:
+    get:
+      tags:
+      - events
+      summary: "Get elapsed time span between two events."
+      operationId: getEventSpan
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle1
+        in: path
+        required: true
+        type: string
+        description: "The unique identifier for the first event."
+      - name: handle2
+        in: path
+        required: true
+        type: string
+        description: "The unique identifier for the second event."
+      - name: as_age
+        in: query
+        required: false
+        type: boolean
+        default: true
+        description: "Indicates whether to return result as an age or not."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for the translated string if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      - name: precision
+        in: query
+        required: false
+        type: integer
+        default: 2
+        description: >
+          Selects the number of significant levels for the string representation. Values may be:
+
+            Precision | Description
+            --------- | -----------
+            1 | Only the most significant level (year, month, day)
+            2 | Only the two most significant levels (year, month, day)
+            3 | At most three items of signifance (year, month, day)
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/Span"
+        400:
+          description: "Bad Request: Bad syntax or parameter."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Event not found."
+    
 ##############################################################################
 # Endpoint - Places
 ##############################################################################
@@ -5330,6 +5385,17 @@ definitions:
       source_media_types:
         - Microfilm
 
+##############################################################################
+# Model - Span
+##############################################################################
+
+  Span:
+    type: object
+    properties:
+      span:
+        type: string
+        description: "A description of a period of elapsed time."
+        example: "82 years, 7 months, 28 days"
 
 ##############################################################################
 # Model - Backlinks

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -282,6 +282,11 @@ paths:
             primary_parent_family | The primary parent family record
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -495,6 +500,11 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -700,6 +710,11 @@ paths:
             place | The place record for the event
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -940,6 +955,11 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1111,6 +1131,11 @@ paths:
             source | The source record cited from
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1282,6 +1307,11 @@ paths:
             reporef_list | The list of referenced repository records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1451,6 +1481,11 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1619,6 +1654,11 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -1963,6 +2003,11 @@ paths:
             all | Returns all possible records listed below
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."
@@ -2074,6 +2119,11 @@ paths:
         required: false
         type: string
         description: "A comma delimited list of specific top level keys to omit from a response, keeping all others."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for translated strings if one other than the current default is desired. Should be a valid language code from the available list of translations."
       responses:
         200:
           description: "OK: Successful operation."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -210,6 +210,7 @@ paths:
             gramps_id | The user assigned Gramps identifier for the person
             name | The sort name of the person
             private | Indicates whether the record is private or not
+            soundex | The soundex code for the surname of the person
             surname | The surname of the person, taking into consideration the given name and suffix for people who share the same surname
       - name: filter
         in: query
@@ -310,6 +311,12 @@ paths:
             primary_parent_family | The primary parent family record
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: locale
         in: query
         required: false
@@ -455,6 +462,7 @@ paths:
             gramps_id | The user assigned Gramps identifier for the family
             private | Indicates whether the record is private or not
             name | The surname of the father or, if none present, the mother of the family taking into consideration the given name and suffix for families who share the same surname
+            soundex | The soundex code for the surname of the father or, if none present, the mother of the family
             type | The relationship type for the family
       - name: filter
         in: query
@@ -553,6 +561,12 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: soundex
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether to include the soundex code for the surname or not."
       - name: locale
         in: query
         required: false

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -194,6 +194,23 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For people the available keys are:
+
+            Key | Description
+            --- | -----------
+            birth | The birth date of the person
+            change | The time the record was last updated
+            death | The death date of the person
+            gender | The gender of the person
+            gramps_id | The user assigned Gramps identifier for the person
+            name | The sort name of the person
+            private | Indicates whether the record is private or not
+            surname | The surname of the person, taking into consideration the given name and suffix for people who share the same surname
       - name: filter
         in: query
         required: false
@@ -425,6 +442,20 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For families the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            gramps_id | The user assigned Gramps identifier for the family
+            private | Indicates whether the record is private or not
+            name | The surname of the father or, if none present, the mother of the family taking into consideration the given name and suffix for families who share the same surname
+            type | The relationship type for the family
       - name: filter
         in: query
         required: false
@@ -652,6 +683,22 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For events the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            date | The event date
+            description | The event description
+            gramps_id | The user assigned Gramps identifier for the event
+            place | The event place
+            private | Indicates whether the record is private or not
+            type | The event type
       - name: filter
         in: query
         required: false
@@ -922,6 +969,22 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For places the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            gramps_id | The user assigned Gramps identifier for the place
+            latitude | The latitude for the place
+            longitude | The longitude for the place
+            private | Indicates whether the record is private or not
+            title | The title or name of the place
+            type | The place type
       - name: filter
         in: query
         required: false
@@ -1109,6 +1172,20 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For citations the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            confidence | The confidence level for the citation
+            date | The date of the citation
+            gramps_id | The user assigned Gramps identifier for the citation
+            private | Indicates whether the record is private or not
       - name: filter
         in: query
         required: false
@@ -1296,6 +1373,22 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For sources the available keys are:
+
+            Key | Description
+            --- | -----------
+            abbrev | The abbreviation for the source
+            author | The author of the source
+            change | The time the record was last updated
+            gramps_id | The user assigned Gramps identifier for the source
+            private | Indicates whether the record is private or not
+            pubinfo | The publication information for the source
+            title | The title of the source
       - name: filter
         in: query
         required: false
@@ -1478,6 +1571,20 @@ paths:
         type: integer
         default: 0
         description: "The given number of items to skip over before starting to return results. By default none are skipped."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For repositories the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            gramps_id | The user assigned Gramps identifier for the repository
+            name | The name of the repository
+            private | Indicates whether the record is private or not
+            type | The type of repository
       - name: limit
         in: query
         required: false
@@ -1666,6 +1773,22 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For media the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            date | The date associated with the media item
+            gramps_id | The user assigned Gramps identifier for the media item
+            mime | The mime type of the media item
+            path | The path to the media item
+            private | Indicates whether the record is private or not
+            title | The title for the media item
       - name: filter
         in: query
         required: false
@@ -2019,6 +2142,20 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For notes the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            gramps_id | The user assigned Gramps identifier for the note item
+            private | Indicates whether the record is private or not
+            text | The note text
+            type | The note type
       - name: filter
         in: query
         required: false
@@ -2213,6 +2350,19 @@ paths:
         required: false
         type: integer
         description: "The maximum number of items to be returned. By default all are returned."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For notes the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            color | The color for the tag
+            name | The name of the tag
+            priority | The priority of the tag
       - name: strip
         in: query
         required: false

--- a/tests/test_endpoints/test_citations.py
+++ b/tests/test_endpoints/test_citations.py
@@ -55,9 +55,9 @@ class TestCitations(unittest.TestCase):
         self.assertEqual(result.json[0]["source_handle"], "b39fe3f390e30bd2b99")
         # check last record is expected citation
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["gramps_id"], "C2853")
-        self.assertEqual(result.json[last]["handle"], "c140e0925ac0adcf8c4")
-        self.assertEqual(result.json[last]["source_handle"], "c140d4ef77841431905")
+        self.assertEqual(result.json[last]["gramps_id"], "C2324")
+        self.assertEqual(result.json[last]["handle"], "c140d28761775ca12ba")
+        self.assertEqual(result.json[last]["source_handle"], "VUBKMQTA2XZG1V6QP8")
 
     def test_citations_endpoint_422(self):
         """Test response for an invalid parm."""

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -50,14 +50,14 @@ class TestFamilies(unittest.TestCase):
         result = self.client.get("/api/families/")
         self.assertEqual(len(result.json), get_object_count("families"))
         # check first record is expected family
-        self.assertEqual(result.json[0]["handle"], "03GKQCH37C1SL9C5B3")
-        self.assertEqual(result.json[0]["father_handle"], "B2GKQCPG5WOVS9B4UL")
-        self.assertEqual(result.json[0]["mother_handle"], "83GKQCS0LVSVRX99KO")
+        self.assertEqual(result.json[0]["handle"], "cc82060505948b9e57f")
+        self.assertEqual(result.json[0]["father_handle"], "cc82060504445ab6deb")
+        self.assertEqual(result.json[0]["mother_handle"], "cc8206050980ea622d0")
         # check last record is expected family
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["handle"], "d64cc45259c01f324b4")
-        self.assertEqual(result.json[last]["father_handle"], "d64cc45258f454e7dac")
-        self.assertEqual(result.json[last]["mother_handle"], "d64cc452655308a46f8")
+        self.assertEqual(result.json[last]["handle"], "WYAKQC3ELT2539P9W2")
+        self.assertEqual(result.json[last]["father_handle"], "B5QKQCZM5CDWEV4SP4")
+        self.assertEqual(result.json[last]["mother_handle"], "LYAKQCT2QKFQUVU4AF")
 
     def test_families_endpoint_422(self):
         """Test response for an invalid parm."""
@@ -135,62 +135,45 @@ class TestFamilies(unittest.TestCase):
                     {
                         "birth": {
                             "age": "0 days",
-                            "date": "",
-                            "place": "Gadsden, Etowah, AL, USA",
+                            "date": "203 (Islamic)",
+                            "place": "",
                             "type": "Birth",
                         },
                         "death": {},
-                        "handle": "S3GKQCSAUG5LKNW2AK",
-                        "name_given": "Sarah",
-                        "name_surname": "Reed",
-                        "sex": "F",
+                        "handle": "cc82060516c6c141500",
+                        "name_given": "صالح",
+                        "name_surname": "",
+                        "sex": "M",
                     }
                 ],
                 "divorce": {},
-                "events": [
-                    {
-                        "date": "1879-07-25",
-                        "place": "Greensboro, NC, USA",
-                        "span": "0 days",
-                        "type": "Marriage",
-                    }
-                ],
+                "events": [],
                 "father": {
                     "birth": {
                         "age": "0 days",
-                        "date": "1847-06-28",
-                        "place": "El Campo, Wharton, TX, USA",
+                        "date": "164-03-00 (Islamic)",
+                        "place": "",
                         "type": "Birth",
                     },
                     "death": {
-                        "age": "44 years, 8 months, 7 days",
-                        "date": "1892-03-05",
-                        "place": "Plymouth, Marshall, IN, USA",
+                        "age": "77 years, 11 days",
+                        "date": "241-03-12 (Islamic)",
+                        "place": "",
                         "type": "Death",
                     },
-                    "handle": "B2GKQCPG5WOVS9B4UL",
-                    "name_given": "Edward",
-                    "name_surname": "Reed",
+                    "handle": "cc82060504445ab6deb",
+                    "name_given": "أحمد",
+                    "name_surname": "",
                     "sex": "M",
                 },
-                "handle": "03GKQCH37C1SL9C5B3",
-                "marriage": {
-                    "date": "1879-07-25",
-                    "place": "Greensboro, NC, USA",
-                    "span": "0 days",
-                    "type": "Marriage",
-                },
+                "handle": "cc82060505948b9e57f",
+                "marriage": {},
                 "mother": {
-                    "birth": {
-                        "age": "0 days",
-                        "date": "",
-                        "place": "Jacksonville, NC, USA",
-                        "type": "Birth",
-                    },
-                    "death": {},
-                    "handle": "83GKQCS0LVSVRX99KO",
-                    "name_given": "Ellen",
-                    "name_surname": "Reed",
+                    "birth": {},
+                    "death": {"date": "234 (Islamic)", "place": "", "type": "Death"},
+                    "handle": "cc8206050980ea622d0",
+                    "name_given": "العباسة",
+                    "name_surname": "الفضل",
                     "sex": "F",
                 },
                 "relationship": "Married",

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -134,6 +134,7 @@ class TestFamilies(unittest.TestCase):
                 "children": [
                     {
                         "birth": {
+                            "age": "0 days",
                             "date": "",
                             "place": "Gadsden, Etowah, AL, USA",
                             "type": "Birth",
@@ -150,16 +151,19 @@ class TestFamilies(unittest.TestCase):
                     {
                         "date": "1879-07-25",
                         "place": "Greensboro, NC, USA",
+                        "span": "0 days",
                         "type": "Marriage",
                     }
                 ],
                 "father": {
                     "birth": {
+                        "age": "0 days",
                         "date": "1847-06-28",
                         "place": "El Campo, Wharton, TX, USA",
                         "type": "Birth",
                     },
                     "death": {
+                        "age": "44 years, 8 months, 7 days",
                         "date": "1892-03-05",
                         "place": "Plymouth, Marshall, IN, USA",
                         "type": "Death",
@@ -173,10 +177,12 @@ class TestFamilies(unittest.TestCase):
                 "marriage": {
                     "date": "1879-07-25",
                     "place": "Greensboro, NC, USA",
+                    "span": "0 days",
                     "type": "Marriage",
                 },
                 "mother": {
                     "birth": {
+                        "age": "0 days",
                         "date": "",
                         "place": "Jacksonville, NC, USA",
                         "type": "Birth",
@@ -290,6 +296,7 @@ class TestFamiliesHandle(unittest.TestCase):
                 "children": [
                     {
                         "birth": {
+                            "age": "0 days",
                             "date": "1983-10-05",
                             "place": "Ottawa, La Salle, IL, USA",
                             "type": "Birth",
@@ -302,6 +309,7 @@ class TestFamiliesHandle(unittest.TestCase):
                     },
                     {
                         "birth": {
+                            "age": "0 days",
                             "date": "1985-02-11",
                             "place": "Ottawa, La Salle, IL, USA",
                             "type": "Birth",
@@ -318,11 +326,13 @@ class TestFamiliesHandle(unittest.TestCase):
                     {
                         "date": "1979-01-06",
                         "place": "Farmington, MO, USA",
+                        "span": "0 days",
                         "type": "Marriage",
                     }
                 ],
                 "father": {
                     "birth": {
+                        "age": "0 days",
                         "date": "1955-07-31",
                         "place": "Ottawa, La Salle, IL, USA",
                         "type": "Birth",
@@ -337,10 +347,16 @@ class TestFamiliesHandle(unittest.TestCase):
                 "marriage": {
                     "date": "1979-01-06",
                     "place": "Farmington, MO, USA",
+                    "span": "0 days",
                     "type": "Marriage",
                 },
                 "mother": {
-                    "birth": {"date": "1957-01-31", "place": "", "type": "Birth"},
+                    "birth": {
+                        "age": "0 days",
+                        "date": "1957-01-31",
+                        "place": "",
+                        "type": "Birth",
+                    },
                     "death": {},
                     "handle": "JFWJQCRREDFKZLDKVD",
                     "name_given": "Elizabeth",

--- a/tests/test_endpoints/test_media.py
+++ b/tests/test_endpoints/test_media.py
@@ -50,14 +50,14 @@ class TestMedia(unittest.TestCase):
         result = self.client.get("/api/media/")
         self.assertEqual(len(result.json), get_object_count("media"))
         # check first record is expected media
-        self.assertEqual(result.json[0]["gramps_id"], "O0010")
-        self.assertEqual(result.json[0]["handle"], "238CGQ939HG18SS5MG")
-        self.assertEqual(result.json[0]["path"], "1897_expeditionsmannschaft_rio_a.jpg")
+        self.assertEqual(result.json[0]["gramps_id"], "O0000")
+        self.assertEqual(result.json[0]["handle"], "b39fe1cfc1305ac4a21")
+        self.assertEqual(result.json[0]["path"], "scanned_microfilm.png")
         # check last record is expected media
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["gramps_id"], "O0000")
-        self.assertEqual(result.json[last]["handle"], "b39fe1cfc1305ac4a21")
-        self.assertEqual(result.json[last]["path"], "scanned_microfilm.png")
+        self.assertEqual(result.json[last]["gramps_id"], "O0009")
+        self.assertEqual(result.json[last]["handle"], "78V2GQX2FKNSYQ3OHE")
+        self.assertEqual(result.json[last]["path"], "Gunnlaugur_Larusson_-_Yawn.jpg")
 
     def test_media_endpoint_422(self):
         """Test response for an invalid parm."""

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -51,17 +51,17 @@ class TestPeople(unittest.TestCase):
         result = self.client.get("/api/people/")
         self.assertEqual(len(result.json), get_object_count("people"))
         # check first record is expected person
-        self.assertEqual(result.json[0]["gramps_id"], "I0552")
-        self.assertEqual(result.json[0]["primary_name"]["first_name"], "Martha")
+        self.assertEqual(result.json[0]["gramps_id"], "I2110")
+        self.assertEqual(result.json[0]["primary_name"]["first_name"], "محمد")
         self.assertEqual(
-            result.json[0]["primary_name"]["surname_list"][0]["surname"], "Nielsen"
+            result.json[0]["primary_name"]["surname_list"][0]["surname"], ""
         )
         # check last record is expected person
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["gramps_id"], "I2156")
-        self.assertEqual(result.json[last]["primary_name"]["first_name"], "蘭")
+        self.assertEqual(result.json[last]["gramps_id"], "I0247")
+        self.assertEqual(result.json[last]["primary_name"]["first_name"], "Allen")
         self.assertEqual(
-            result.json[last]["primary_name"]["surname_list"][0]["surname"], "賈"
+            result.json[last]["primary_name"]["surname_list"][0]["surname"], "鈴木"
         )
 
     def test_people_endpoint_422(self):
@@ -131,77 +131,139 @@ class TestPeople(unittest.TestCase):
         self.assertEqual(
             result.json[0]["profile"],
             {
-                "birth": {},
-                "death": {},
-                "events": [],
+                "birth": {
+                    "age": "0 days",
+                    "date": "570-04-19",
+                    "place": "",
+                    "type": "Birth",
+                },
+                "death": {
+                    "age": "62 years, 1 months, 19 days",
+                    "date": "632-06-08",
+                    "place": "",
+                    "type": "Death",
+                },
+                "events": [
+                    {
+                        "age": "0 days",
+                        "date": "570-04-19",
+                        "place": "",
+                        "type": "Birth",
+                    },
+                    {
+                        "age": "62 years, 1 months, 19 days",
+                        "date": "632-06-08",
+                        "place": "",
+                        "type": "Death",
+                    },
+                    {
+                        "age": "39 years, 8 months, 13 days",
+                        "date": "610",
+                        "place": "",
+                        "type": "Marriage",
+                    },
+                ],
                 "families": [
                     {
-                        "children": [
-                            {
-                                "birth": {
-                                    "age": "0 days",
-                                    "date": "after 1737-10-01",
-                                    "place": "Maryville, MO, USA",
-                                    "type": "Birth",
-                                },
-                                "death": {
-                                    "age": "less than 49 years, 7 months, 18 days",
-                                    "date": "1787-05-20",
-                                    "place": "Wooster, OH, USA",
-                                    "type": "Death",
-                                },
-                                "handle": "E04KQC637O9JLP5PNM",
-                                "name_given": "John",
-                                "name_surname": "Adkins",
-                                "sex": "M",
-                            }
-                        ],
+                        "children": [],
                         "divorce": {},
-                        "events": [
-                            {
-                                "date": "",
-                                "place": "",
-                                "span": "unknown",
-                                "type": "Marriage",
-                            }
-                        ],
+                        "events": [],
                         "father": {
                             "birth": {
                                 "age": "0 days",
-                                "date": "",
-                                "place": "Ketchikan, AK, USA",
+                                "date": "570-04-19",
+                                "place": "",
                                 "type": "Birth",
                             },
-                            "death": {},
-                            "handle": "JZ3KQCSRW7R368NLSH",
-                            "name_given": "Robert Sr.",
-                            "name_surname": "Adkins",
+                            "death": {
+                                "age": "62 years, 1 months, 19 days",
+                                "date": "632-06-08",
+                                "place": "",
+                                "type": "Death",
+                            },
+                            "handle": "cc8205d872f532ab14e",
+                            "name_given": "محمد",
+                            "name_surname": "",
                             "sex": "M",
                         },
-                        "handle": "TZ3KQCJ3PNQHI6S8VO",
-                        "marriage": {
-                            "date": "",
-                            "place": "",
-                            "span": "0 days",
-                            "type": "Marriage",
-                        },
+                        "handle": "cc8205d874433c12fd8",
+                        "marriage": {},
                         "mother": {
                             "birth": {},
                             "death": {},
-                            "handle": "004KQCGYT27EEPQHK",
-                            "name_given": "Martha",
-                            "name_surname": "Nielsen",
+                            "handle": "cc8205d87831c772e87",
+                            "name_given": "عائشة",
+                            "name_surname": "",
                             "sex": "F",
                         },
                         "relationship": "Married",
-                    }
+                    },
+                    {
+                        "children": [
+                            {
+                                "birth": {},
+                                "death": {},
+                                "handle": "cc8205d87fd529000ff",
+                                "name_given": "القاسم",
+                                "name_surname": "",
+                                "sex": "M",
+                            },
+                            {
+                                "birth": {},
+                                "death": {},
+                                "handle": "cc8205d883763f02abd",
+                                "name_given": "عبد الله",
+                                "name_surname": "",
+                                "sex": "M",
+                            },
+                            {
+                                "birth": {},
+                                "death": {},
+                                "handle": "cc8205d887376aacba2",
+                                "name_given": "أم كلثوم",
+                                "name_surname": "",
+                                "sex": "F",
+                            },
+                        ],
+                        "divorce": {},
+                        "events": [],
+                        "father": {
+                            "birth": {
+                                "age": "0 days",
+                                "date": "570-04-19",
+                                "place": "",
+                                "type": "Birth",
+                            },
+                            "death": {
+                                "age": "62 years, 1 months, 19 days",
+                                "date": "632-06-08",
+                                "place": "",
+                                "type": "Death",
+                            },
+                            "handle": "cc8205d872f532ab14e",
+                            "name_given": "محمد",
+                            "name_surname": "",
+                            "sex": "M",
+                        },
+                        "handle": "cc8205d87492b90b437",
+                        "marriage": {},
+                        "mother": {
+                            "birth": {},
+                            "death": {},
+                            "handle": "cc8205d87c20350420b",
+                            "name_given": "خديجة",
+                            "name_surname": "",
+                            "sex": "F",
+                        },
+                        "relationship": "Married",
+                    },
                 ],
-                "handle": "004KQCGYT27EEPQHK",
-                "name_given": "Martha",
-                "name_surname": "Nielsen",
+                "handle": "cc8205d872f532ab14e",
+                "name_given": "محمد",
+                "name_surname": "",
                 "other_parent_families": [],
                 "primary_parent_family": {},
-                "sex": "F",
+                "sex": "M",
             },
         )
 

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -139,11 +139,13 @@ class TestPeople(unittest.TestCase):
                         "children": [
                             {
                                 "birth": {
+                                    "age": "0 days",
                                     "date": "after 1737-10-01",
                                     "place": "Maryville, MO, USA",
                                     "type": "Birth",
                                 },
                                 "death": {
+                                    "age": "less than 49 years, 7 months, 18 days",
                                     "date": "1787-05-20",
                                     "place": "Wooster, OH, USA",
                                     "type": "Death",
@@ -155,9 +157,17 @@ class TestPeople(unittest.TestCase):
                             }
                         ],
                         "divorce": {},
-                        "events": [{"date": "", "place": "", "type": "Marriage"}],
+                        "events": [
+                            {
+                                "date": "",
+                                "place": "",
+                                "span": "unknown",
+                                "type": "Marriage",
+                            }
+                        ],
                         "father": {
                             "birth": {
+                                "age": "0 days",
                                 "date": "",
                                 "place": "Ketchikan, AK, USA",
                                 "type": "Birth",
@@ -169,7 +179,12 @@ class TestPeople(unittest.TestCase):
                             "sex": "M",
                         },
                         "handle": "TZ3KQCJ3PNQHI6S8VO",
-                        "marriage": {"date": "", "place": "", "type": "Marriage"},
+                        "marriage": {
+                            "date": "",
+                            "place": "",
+                            "span": "0 days",
+                            "type": "Marriage",
+                        },
                         "mother": {
                             "birth": {},
                             "death": {},
@@ -299,27 +314,32 @@ class TestPeopleHandle(unittest.TestCase):
             result.json["profile"],
             {
                 "birth": {
+                    "age": "0 days",
                     "date": "1906-09-05",
                     "place": "Central City, Muhlenberg, KY, USA",
                     "type": "Birth",
                 },
                 "death": {
+                    "age": "86 years, 9 months, 1 days",
                     "date": "1993-06-06",
                     "place": "Sevierville, TN, USA",
                     "type": "Death",
                 },
                 "events": [
                     {
+                        "age": "0 days",
                         "date": "1906-09-05",
                         "place": "Central City, Muhlenberg, KY, USA",
                         "type": "Birth",
                     },
                     {
+                        "age": "86 years, 9 months, 1 days",
                         "date": "1993-06-06",
                         "place": "Sevierville, TN, USA",
                         "type": "Death",
                     },
                     {
+                        "age": "86 years, 9 months, 3 days",
                         "date": "1993-06-08",
                         "place": "Wenatchee, WA, USA",
                         "type": "Burial",
@@ -334,11 +354,13 @@ class TestPeopleHandle(unittest.TestCase):
                     "children": [
                         {
                             "birth": {
+                                "age": "0 days",
                                 "date": "1889-08-11",
                                 "place": "Panama City, Bay, FL, USA",
                                 "type": "Birth",
                             },
                             "death": {
+                                "age": "72 years, 1 days",
                                 "date": "1961-08-12",
                                 "place": "Butte, MT, USA",
                                 "type": "Death",
@@ -350,11 +372,13 @@ class TestPeopleHandle(unittest.TestCase):
                         },
                         {
                             "birth": {
+                                "age": "0 days",
                                 "date": "1892-09-25",
                                 "place": "New Castle, Henry, IN, USA",
                                 "type": "Birth",
                             },
                             "death": {
+                                "age": "78 years, 2 months, 22 days",
                                 "date": "1970-12-17",
                                 "place": "",
                                 "type": "Death",
@@ -366,11 +390,13 @@ class TestPeopleHandle(unittest.TestCase):
                         },
                         {
                             "birth": {
+                                "age": "0 days",
                                 "date": "1906-09-05",
                                 "place": "Central City, Muhlenberg, KY, USA",
                                 "type": "Birth",
                             },
                             "death": {
+                                "age": "86 years, 9 months, 1 days",
                                 "date": "1993-06-06",
                                 "place": "Sevierville, TN, USA",
                                 "type": "Death",
@@ -386,16 +412,19 @@ class TestPeopleHandle(unittest.TestCase):
                         {
                             "date": "1888-08-09",
                             "place": "Springfield, Sangamon, IL, USA",
+                            "span": "0 days",
                             "type": "Marriage",
                         }
                     ],
                     "father": {
                         "birth": {
+                            "age": "0 days",
                             "date": "1867-01-23",
                             "place": "Durango, La Plata, CO, USA",
                             "type": "Birth",
                         },
                         "death": {
+                            "age": "52 years, 1 months, 18 days",
                             "date": "1919-03-10",
                             "place": "Kokomo, Howard, IN, USA",
                             "type": "Death",
@@ -409,15 +438,18 @@ class TestPeopleHandle(unittest.TestCase):
                     "marriage": {
                         "date": "1888-08-09",
                         "place": "Springfield, Sangamon, IL, USA",
+                        "span": "0 days",
                         "type": "Marriage",
                     },
                     "mother": {
                         "birth": {
+                            "age": "0 days",
                             "date": "1869-07-08",
                             "place": "Oxnard, Ventura, CA, USA",
                             "type": "Birth",
                         },
                         "death": {
+                            "age": "72 years, 9 months, 13 days",
                             "date": "1942-04-21",
                             "place": "Kokomo, Howard, IN, USA",
                             "type": "Death",

--- a/tests/test_endpoints/test_places.py
+++ b/tests/test_endpoints/test_places.py
@@ -50,14 +50,13 @@ class TestPlaces(unittest.TestCase):
         result = self.client.get("/api/places/")
         self.assertEqual(len(result.json), get_object_count("places"))
         # check first record is expected place
-        self.assertEqual(result.json[0]["gramps_id"], "P0852")
-        self.assertEqual(result.json[0]["handle"], "00BKQC7SA8C9NCGB0A")
-        self.assertEqual(result.json[0]["title"], "Deltona, FL")
+        self.assertEqual(result.json[0]["gramps_id"], "P0441")
+        self.assertEqual(result.json[0]["handle"], "dd445e5bfcc17bd1838")
         # check last record is expected place
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["gramps_id"], "P0441")
-        self.assertEqual(result.json[last]["handle"], "dd445e5bfcc17bd1838")
-        self.assertEqual(result.json[last]["title"], "")
+        self.assertEqual(result.json[last]["gramps_id"], "P0438")
+        self.assertEqual(result.json[last]["handle"], "d583a5b8b586fb992c8")
+        self.assertEqual(result.json[last]["title"], "Σιάτιστα")
 
     def test_places_endpoint_422(self):
         """Test response for an invalid parm."""

--- a/tests/test_endpoints/test_relations.py
+++ b/tests/test_endpoints/test_relations.py
@@ -84,9 +84,9 @@ class TestRelation(unittest.TestCase):
         )
         self.assertEqual(result.status_code, 422)
         result = self.client.get(
-            "/api/relations/9BXKQC1PVLPYFMD6IX/ORFKQC4KLWEGTGR19L?locale=1"
+            "/api/relations/9BXKQC1PVLPYFMD6IX/ORFKQC4KLWEGTGR19L?locale=de"
         )
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json["relationship_string"], "Stief-/Adoptivalttante")
 
 
 class TestRelations(unittest.TestCase):
@@ -143,4 +143,15 @@ class TestRelations(unittest.TestCase):
         )
         self.assertEqual(
             result.json[0]["relationship_string"], "second great stepgrandaunt"
+        )
+        # check locale parm working
+        result = self.client.get(
+            "/api/relations/9BXKQC1PVLPYFMD6IX/ORFKQC4KLWEGTGR19L/all?locale"
+        )
+        self.assertEqual(result.status_code, 422)
+        result = self.client.get(
+            "/api/relations/9BXKQC1PVLPYFMD6IX/ORFKQC4KLWEGTGR19L/all?locale=de"
+        )
+        self.assertEqual(
+            result.json[0]["relationship_string"], "Stief-/Adoptivalttante"
         )

--- a/tests/test_endpoints/test_sources.py
+++ b/tests/test_endpoints/test_sources.py
@@ -50,14 +50,14 @@ class TestSources(unittest.TestCase):
         result = self.client.get("/api/sources/")
         self.assertEqual(len(result.json), get_object_count("sources"))
         # check first record is expected source
-        self.assertEqual(result.json[0]["gramps_id"], "S0002")
-        self.assertEqual(result.json[0]["handle"], "VUBKMQTA2XZG1V6QP8")
-        self.assertEqual(result.json[0]["title"], "World of the Wierd")
+        self.assertEqual(result.json[0]["gramps_id"], "S0001")
+        self.assertEqual(result.json[0]["handle"], "c140d4ef77841431905")
+        self.assertEqual(result.json[0]["title"], "All possible citations")
         # check last record is expected source
         last = len(result.json) - 1
-        self.assertEqual(result.json[last]["gramps_id"], "S0001")
-        self.assertEqual(result.json[last]["handle"], "c140d4ef77841431905")
-        self.assertEqual(result.json[last]["title"], "All possible citations")
+        self.assertEqual(result.json[last]["gramps_id"], "S0002")
+        self.assertEqual(result.json[last]["handle"], "VUBKMQTA2XZG1V6QP8")
+        self.assertEqual(result.json[last]["title"], "World of the Wierd")
 
     def test_sources_endpoint_422(self):
         """Test response for an invalid parm."""


### PR DESCRIPTION
@DavidMStraub this one does the following:

1. Add age and span as keywords to the profile= query parm.  Age is self explanatory, the keyword span is for familial events and instead of being measured off birth is measured off of the marriage or marriage equivalent.  So if a couple had their 50th wedding anniversary the span would report "50 years", or if they divorced it would have the length of time the marriage lasted.  I did not add proper locale= support here yet, need to look at that. That can always come in another PR.

2. Add a /api/events/{handle1}/span/{handle2} end point that can be used to calculate the span between any two events. This supports locale={language} for the returned string.

3. I updated the relationship calculator again so it now uses the localized plugin if one is available and it too now supports locale={language} for the returned string when possible.
