### PR TITLE
Add password reset mechanism (fixes #89)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -63,7 +63,11 @@ from .resources.types import (
     DefaultTypesResource,
     TypesResource,
 )
-from .resources.user import UserChangePasswordResource
+from .resources.user import (
+    UserChangePasswordResource,
+    UserResetPasswordResource,
+    UserTriggerResetPasswordResource,
+)
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
 
@@ -157,6 +161,12 @@ register_endpt(ExportersResource, "/exporters/", "exporters")
 register_endpt(MetadataResource, "/metadata/", "metadata")
 # User
 register_endpt(UserChangePasswordResource, "/user/password/change", "change_password")
+register_endpt(UserResetPasswordResource, "/user/password/reset", "reset_password")
+register_endpt(
+    UserTriggerResetPasswordResource,
+    "/user/password/reset/trigger",
+    "trigger_reset_password",
+)
 # Search
 register_endpt(SearchResource, "/search/", "search")
 

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -161,10 +161,10 @@ register_endpt(ExportersResource, "/exporters/", "exporters")
 register_endpt(MetadataResource, "/metadata/", "metadata")
 # User
 register_endpt(UserChangePasswordResource, "/user/password/change", "change_password")
-register_endpt(UserResetPasswordResource, "/user/password/reset", "reset_password")
+register_endpt(UserResetPasswordResource, "/user/password/reset/", "reset_password")
 register_endpt(
     UserTriggerResetPasswordResource,
-    "/user/password/reset/trigger",
+    "/user/password/reset/trigger/",
     "trigger_reset_password",
 )
 # Search

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -20,6 +20,7 @@
 
 """Authentication endpoint blueprint."""
 
+
 from flask import abort, current_app
 from flask_jwt_extended import (
     create_access_token,

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -65,8 +65,7 @@ def handle_reset_token(username: str, email: str, token: str):
     send_email(
         subject="Password reset",
         body="{}, your token: {}".format(username, token),
-        sender="from@example.com",
-        recipients=[email],
+        to=[email],
     )
 
 
@@ -95,7 +94,10 @@ class UserTriggerResetPasswordResource(Resource):
             # password reset has to be triggered within 24h
             expires_delta=datetime.timedelta(days=1),
         )
-        handle_reset_token(username=args["username"], email=email, token=token)
+        try:
+            handle_reset_token(username=args["username"], email=email, token=token)
+        except ValueError:
+            abort(500)
         return "", 201
 
 

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -20,12 +20,19 @@
 
 """User administration resources."""
 
+import datetime
+
 from flask import abort, current_app
-from flask_jwt_extended import get_jwt_identity
+from flask_jwt_extended import create_access_token, get_jwt_claims, get_jwt_identity
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from webargs import fields
 from webargs.flaskparser import use_args
 
-from . import ProtectedResource
+from . import ProtectedResource, Resource
+
+
+limiter = Limiter(key_func=get_remote_address)
 
 
 class UserChangePasswordResource(ProtectedResource):
@@ -48,5 +55,60 @@ class UserChangePasswordResource(ProtectedResource):
         username = get_jwt_identity()
         if not auth_provider.authorized(username, args["old_password"]):
             abort(403)
+        auth_provider.modify_user(name=username, password=args["new_password"])
+        return "", 201
+
+
+def handle_reset_token(username: str, email: str, token: str):
+    """Handle the password reset token."""
+
+
+class UserTriggerResetPasswordResource(Resource):
+    """Resource for obtaining a one-time JWT for password reset."""
+
+    @limiter.limit("1/second")
+    @use_args(
+        {"username": fields.Str(required=True)}, location="json",
+    )
+    def post(self, args):
+        """Post username to initiate the password reset."""
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        details = auth_provider.get_user_details(args["username"])
+        if details is None:
+            # user does not exist!
+            abort(404)
+        email = details["email"]
+        token = create_access_token(
+            identity=args["username"],
+            # the hash of the existing password is stored in the token in order
+            # to make sure the rest token can only be used once
+            user_claims={"old_hash": auth_provider.get_pwhash(args["username"])},
+            # password reset has to be triggered within 24h
+            expires_delta=datetime.timedelta(days=1),
+        )
+        handle_reset_token(username=args["username"], email=email, token=token)
+        return "", 201
+
+
+class UserResetPasswordResource(ProtectedResource):
+    """Resource for resetting a user password."""
+
+    @use_args(
+        {"new_password": fields.Str(required=True),}, location="json",
+    )
+    def post(self, args):
+        """Post new password."""
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        if len(args["new_password"]) == "":
+            abort(400)
+        claims = get_jwt_claims()
+        username = get_jwt_identity()
+        # the old PW hash is stored in the reset JWT to check if the token has
+        # been used already
+        if claims["old_hash"] != auth_provider.get_pwhash(username):
+            # the one-time token has been used before!
+            abort(409)
         auth_provider.modify_user(name=username, password=args["new_password"])
         return "", 201

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -62,9 +62,19 @@ class UserChangePasswordResource(ProtectedResource):
 
 def handle_reset_token(username: str, email: str, token: str):
     """Handle the password reset token."""
+    base_url = current_app.config["BASE_URL"]
     send_email(
-        subject="Password reset",
-        body="{}, your token: {}".format(username, token),
+        subject="Reset your Gramps password",
+        body="""You are receiving this e-mail because you (or someone else) have requested the reset of the password for your account.
+
+Please click on the following link, or paste this into your browser to complete the process:
+
+{}/api/user/password/reset?jwt={}
+
+If you did not request this, please ignore this e-mail and your password will remain unchanged.
+""".format(
+            base_url, token
+        ),
         to=[email],
     )
 

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -62,7 +62,7 @@ class UserChangePasswordResource(ProtectedResource):
 
 def handle_reset_token(username: str, email: str, token: str):
     """Handle the password reset token."""
-    base_url = current_app.config["BASE_URL"]
+    base_url = current_app.config["BASE_URL"].rstrip("/")
     send_email(
         subject="Reset your Gramps password",
         body="""You are receiving this e-mail because you (or someone else) have requested the reset of the password for your account.
@@ -101,8 +101,8 @@ class UserTriggerResetPasswordResource(Resource):
             # the hash of the existing password is stored in the token in order
             # to make sure the rest token can only be used once
             user_claims={"old_hash": auth_provider.get_pwhash(args["username"])},
-            # password reset has to be triggered within 24h
-            expires_delta=datetime.timedelta(days=1),
+            # password reset has to be triggered within 1h
+            expires_delta=datetime.timedelta(hours=1),
         )
         try:
             handle_reset_token(username=args["username"], email=email, token=token)

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -74,12 +74,23 @@ def get_buffer_for_file(filename: str, delete=True) -> BinaryIO:
     return buffer
 
 
-def send_email(subject: str, body: str, sender: str, recipients: Sequence[str]):
+def send_email(subject: str, body: str, sender: str, recipients: Sequence[str]) -> None:
     """Send an e-mail message."""
     msg = EmailMessage()
     msg.set_content(body)
     msg["Subject"] = subject
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
-    with smtplib.SMTP("localhost") as smtp:
+
+    host = current_app.config["EMAIL_HOST"]
+    port = current_app.config["EMAIL_PORT"]
+    user = current_app.config["EMAIL_HOST_USER"]
+    password = current_app.config["EMAIL_HOST_PASSWORD"]
+    use_tls = current_app.config["EMAIL_USE_TLS"]
+
+    with smtplib.SMTP(host=host, port=port) as smtp:
+        if use_tls:
+            smtp.starttls()
+        if user:
+            smtp.login(user, password)
         smtp.send_message(msg)

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -22,7 +22,9 @@
 
 import io
 import os
-from typing import BinaryIO
+import smtplib
+from email.message import EmailMessage
+from typing import BinaryIO, Sequence
 
 from flask import abort, current_app, g
 from gramps.gen.const import GRAMPS_LOCALE
@@ -70,3 +72,14 @@ def get_buffer_for_file(filename: str, delete=True) -> BinaryIO:
     if delete:
         os.remove(filename)
     return buffer
+
+
+def send_email(subject: str, body: str, sender: str, recipients: Sequence[str]):
+    """Send an e-mail message."""
+    msg = EmailMessage()
+    msg.set_content(body)
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = ", ".join(recipients)
+    with smtplib.SMTP("localhost") as smtp:
+        smtp.send_message(msg)

--- a/gramps_webapi/auth.py
+++ b/gramps_webapi/auth.py
@@ -99,12 +99,16 @@ class SQLAuth(AuthProvider):
         """Get the GUID of an existing user by username."""
         with self.session_scope() as session:
             user_id = session.query(User.id).filter_by(name=name).scalar()
+            if user_id is None:
+                raise ValueError("User {} not found".format(name))
         return user_id
 
     def delete_user(self, name: str) -> None:
         """Delete an existing user."""
         with self.session_scope() as session:
             user = session.query(User).filter_by(name=name).scalar()
+            if user is None:
+                raise ValueError("User {} not found".format(name))
             session.delete(user)
 
     def modify_user(

--- a/gramps_webapi/auth.py
+++ b/gramps_webapi/auth.py
@@ -23,7 +23,7 @@
 import uuid
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
@@ -125,7 +125,8 @@ class SQLAuth(AuthProvider):
                 user.pwhash = hash_password(password)
             if fullname is not None:
                 user.fullname = fullname
-            user.email = email  # also for None since nullable
+            if email is not None:
+                user.email = email
             if role is not None:
                 user.role = role
 
@@ -143,7 +144,7 @@ class SQLAuth(AuthProvider):
             user = session.query(User).filter_by(name=username).one()
             return user.pwhash
 
-    def get_user_details(self, username: str) -> Optional[str]:
+    def get_user_details(self, username: str) -> Optional[Dict[str, Any]]:
         """Return details about a user."""
         with self.session_scope() as session:
             user = session.query(User).filter_by(name=username).scalar()

--- a/gramps_webapi/auth.py
+++ b/gramps_webapi/auth.py
@@ -98,13 +98,13 @@ class SQLAuth(AuthProvider):
     def get_guid(self, name: str) -> None:
         """Get the GUID of an existing user by username."""
         with self.session_scope() as session:
-            user_id = session.query(User.id).filter_by(name=name).one()
+            user_id = session.query(User.id).filter_by(name=name).scalar()
         return user_id
 
     def delete_user(self, name: str) -> None:
         """Delete an existing user."""
         with self.session_scope() as session:
-            user = session.query(User).filter_by(name=name).one()
+            user = session.query(User).filter_by(name=name).scalar()
             session.delete(user)
 
     def modify_user(

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -28,6 +28,11 @@ class DefaultConfig(object):
 
     PROPAGATE_EXCEPTIONS = True
     SEARCH_INDEX_DIR = "indexdir"
+    EMAIL_HOST = "localhost"
+    EMAIL_PORT = 0
+    EMAIL_HOST_USER = ""
+    EMAIL_HOST_PASSWORD = ""
+    EMAIL_USE_TLS = False
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -34,6 +34,7 @@ class DefaultConfig(object):
     EMAIL_HOST_PASSWORD = ""
     EMAIL_USE_TLS = False
     DEFAULT_FROM_EMAIL = ""
+    BASE_URL = "http://localhost/"
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -33,6 +33,7 @@ class DefaultConfig(object):
     EMAIL_HOST_USER = ""
     EMAIL_HOST_PASSWORD = ""
     EMAIL_USE_TLS = False
+    DEFAULT_FROM_EMAIL = ""
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -169,6 +169,34 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid token."
 
+
+  /user/password/reset/trigger:
+    post:
+      tags:
+      - authentication
+      summary: "Trigger a password reset e-mail."
+      operationId: triggerResetUserPassword
+      parameters:
+      - name: username
+        in: body
+        schema:
+          type: object
+          properties:
+            username:
+              description: "The username of the user whose password should be reset."
+              type: string
+      responses:
+        201:
+          description: "OK: e-mail successfully sent."
+        404:
+          description: "Not found: user does not exist or has no e-mail address."
+        422:
+          description: "Unprocessable Entity: missing username."
+        429:
+          description: "Too many Requests: repeat in 1 second."
+        500:
+          description: "Server Error, e.g. failed to send e-mail."
+
 ##############################################################################
 # Endpoint - People
 ##############################################################################

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -197,6 +197,42 @@ paths:
         500:
           description: "Server Error, e.g. failed to send e-mail."
 
+
+  /user/password/reset:
+    post:
+      tags:
+      - authentication
+      summary: "Reset a user's password using a token from a reset e-mail."
+      operationId: resetUserPassword
+      security:
+        - Bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        type: string
+        description: "The one-time password reset token."
+      - name: new_password
+        in: body
+        schema:
+          type: object
+          properties:
+            new_password:
+              description: "The user's new password."
+              type: string
+      responses:
+        201:
+          description: "OK: password successfully reset."
+        400:
+          description: "Bad Request: Empty password."
+        405:
+          description: "Method Not Allowed: No authorization provider configured."
+        409:
+          description: "Conflict: One-time token has already been used."
+        422:
+          description: "Unprocessable Entity: missing password."
+
+
 ##############################################################################
 # Endpoint - People
 ##############################################################################

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -231,6 +231,25 @@ paths:
           description: "Conflict: One-time token has already been used."
         422:
           description: "Unprocessable Entity: missing password."
+    get:
+      tags:
+      - authentication
+      summary: "Display the password reset form."
+      security:
+        - Bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        type: string
+        description: "The one-time password reset token."
+      responses:
+        200:
+          description: "OK: Form or error message displayed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        405:
+          description: "Method Not Allowed: No authorization provider configured."
 
 
 ##############################################################################

--- a/gramps_webapi/templates/reset_password.html
+++ b/gramps_webapi/templates/reset_password.html
@@ -1,0 +1,60 @@
+{% extends "reset_password_base.html" %}
+{% block title %}Reset Password{% endblock %}
+
+{% block main %}
+<div id="form">
+  <h1>Reset password for {{username}}</h1>
+  <input type="password" id="password"></input>
+  <button id="submit" onclick="submit()">Submit</button>
+</div>
+<div id="error" class="error" style="display:none;margin-top:2em;">
+</div>
+<div id="success" class="success" style="display:none;">
+  <img width="200" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaWQ9IkxheWVyXzEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYxMiA3OTI7IiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA2MTIgNzkyIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0MUFENDk7fQo8L3N0eWxlPjxnPjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik01NjIsMzk2YzAtMTQxLjQtMTE0LjYtMjU2LTI1Ni0yNTZTNTAsMjU0LjYsNTAsMzk2czExNC42LDI1NiwyNTYsMjU2UzU2Miw1MzcuNCw1NjIsMzk2TDU2MiwzOTZ6ICAgIE01MDEuNywyOTYuM2wtMjQxLDI0MWwwLDBsLTE3LjIsMTcuMkwxMTAuMyw0MjEuM2w1OC44LTU4LjhsNzQuNSw3NC41bDE5OS40LTE5OS40TDUwMS43LDI5Ni4zTDUwMS43LDI5Ni4zeiIvPjwvZz48L3N2Zz4=">
+  <div>Password successfully updated</div>
+</div>
+
+
+<script>
+  function submit() {
+    const inputPw = document.getElementById("password");
+    const pw = inputPw.value;
+    const urlParams = new URLSearchParams(window.location.search);
+    const jwt = urlParams.get('jwt');
+    fetch(`/api/user/password/reset/?jwt=${jwt}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ new_password: pw })
+    })
+      .then(response => {
+        switch (response.status) {
+          case 201:
+            handleSuccess();
+            break;
+          case 400:
+            handleError("Error: Password not accepted");
+            break;
+          default:
+            handleError("Unexpected error");
+        }
+      });
+  }
+
+  function handleSuccess() {
+    const divErr = document.getElementById("error");
+    const divSuccess = document.getElementById("success");
+    const divForm = document.getElementById("form");
+    divErr.style.display = 'none';
+    divForm.style.display = 'none';
+    divSuccess.style.display = 'block';
+  }
+
+  function handleError(msg) {
+    const divErr = document.getElementById("error");
+    divErr.innerHTML = msg;
+    divErr.style.display = 'block';
+  }
+</script>
+{% endblock %}

--- a/gramps_webapi/templates/reset_password_base.html
+++ b/gramps_webapi/templates/reset_password_base.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>{% block title %}{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html,
+    body {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      font-size: 20px;
+      font-family: sans-serif;
+    }
+
+    h1 {
+      font-weight: normal;
+      font-size: 28px;
+      margin-bottom: 2em;
+    }
+
+    input {
+      font-size: 20px;
+      border: 1px solid #333;
+      border-radius: 3px;
+      padding: 5px 12px;
+      max-width: 100%;
+      margin-right: 5px;
+      margin-bottom: 8px;
+    }
+
+    .content {
+      max-width: 25em;
+      padding: 2em;
+      margin: auto;
+      position: relative;
+      top: 10vh;
+    }
+
+    .error {
+      color: #BF360C;
+    }
+
+    button {
+      color: #333;
+      border: 1px solid #333;
+      border-radius: 3px;
+      padding: 5px 12px;
+      background-color: white;
+      font-size: 20px;
+    }
+
+    button:hover {
+      background-color: #F0F0F0;
+      cursor: pointer;
+    }
+
+    .success {
+      text-align: center;
+      color: #41AD49
+    }
+  </style>
+</head>
+
+<body>
+  <div class="content">
+    {% block main %}
+    {% endblock %}
+  </div>
+</body>
+
+</html>

--- a/gramps_webapi/templates/reset_password_error.html
+++ b/gramps_webapi/templates/reset_password_error.html
@@ -1,0 +1,6 @@
+{% extends "reset_password_base.html" %}
+{% block title %}Reset Password - Error{% endblock %}
+
+{% block main %}
+<p class="error">Error: This token has already been used</p>
+{% endblock %}

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -146,7 +146,7 @@ class TestUser(unittest.TestCase):
             msg = args[0]
             # extract the token from the message body
             body = msg.get_body().get_payload().replace("=\n", "")
-            matches = re.findall(r".*jwt=3D([^\s]+).*", body)
+            matches = re.findall(r".*jwt=([^\s]+).*", body)
             self.assertEqual(len(matches), 1, msg=body)
             token = matches[0]
         # try without token!

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -153,6 +153,13 @@ class TestUser(unittest.TestCase):
             "/api/user/password/reset/", json={"new_password": "789"},
         )
         self.assertEqual(rv.status_code, 401)
+        # try empty PW!
+        rv = self.client.post(
+            "/api/user/password/reset/",
+            headers={"Authorization": "Bearer {}".format(token)},
+            json={"new_password": ""},
+        )
+        self.assertEqual(rv.status_code, 400)
         # now that should work
         rv = self.client.post(
             "/api/user/password/reset/",

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -23,14 +23,15 @@
 import unittest
 from unittest.mock import patch
 
+from flask_jwt_extended import get_jwt_claims, get_jwt_identity
 from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.db import DbTxn
 from gramps.gen.dbstate import DbState
 from gramps.gen.lib import Person, Surname
+from tests.test_endpoints import get_test_client
 
 from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
-from tests.test_endpoints import get_test_client
 
 
 class TestUser(unittest.TestCase):
@@ -114,3 +115,21 @@ class TestUser(unittest.TestCase):
             json={"old_password": "123", "new_password": "456"},
         )
         assert rv.status_code == 403
+
+    def test_reset_password_trigger_invalid_user(self):
+        rv = self.client.post(
+            "/api/user/password/reset/trigger", json={"username": "doesn_exist"}
+        )
+        assert rv.status_code == 404
+
+    def test_reset_password_trigger_status(self):
+        rv = self.client.post(
+            "/api/user/password/reset/trigger", json={"username": "user"}
+        )
+        assert rv.status_code == 201
+
+    def test_reset_password_trigger_token(self):
+        with self.app.test_request_context(
+            "/api/user/password/reset/trigger", json={"username": "user"}
+        ):
+            pass

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -147,7 +147,7 @@ class TestUser(unittest.TestCase):
             # extract the token from the message body
             body = msg.get_body().get_payload().replace("=\n", "")
             matches = re.findall(r".*jwt=3D([^\s]+).*", body)
-            self.assertEqual(len(matches), 1)
+            self.assertEqual(len(matches), 1, msg=body)
             token = matches[0]
         # try without token!
         rv = self.client.post(


### PR DESCRIPTION
This is still a work in progress, but almost done (e.g. API spec still missing). It adds a mechanism to reset a user password via e-mail. 

It works like this:

- Post a username to `/api/user/password/reset/trigger/` (this does *not* require a token)
- The backend sends an e-mail to the user containing a special token (this requires configuring an IMAP server via `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, `EMAIL_USE_TLS`)
- The user clicks the link in the e-mail (I still need to fix the e-mail body) which takes them to `/api/user/password/reset/?jwt=<token>`
- At this endpoint (when using `GET`), a form is displayed to reset the password
- The form `POST`s the password to `/api/user/password/reset`
- Using the reset link again is *not* possible, because the token contains the hash of the old password, which allows to check that it has been used without keeping any state in the DB.
