### PR TITLE
Replace get_dbstate with get_db_handle

### DIFF
--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -29,7 +29,7 @@ from gramps.gen.lib import Media
 from gramps_webapi.const import MIME_JPEG
 
 from .image import ThumbnailHandler
-from .util import get_dbstate, get_media_base_dir
+from .util import get_db_handle, get_media_base_dir
 
 
 class FileHandler:
@@ -45,8 +45,8 @@ class FileHandler:
 
     def _get_media_object(self) -> Media:
         """Get the media object from the database."""
-        dbstate = get_dbstate()
-        return dbstate.db.get_media_from_handle(self.handle)
+        db_handle = get_db_handle()
+        return db_handle.get_media_from_handle(self.handle)
 
     def send_file(self):
         """Send media file to client."""

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -30,7 +30,7 @@ from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from webargs import fields, validate
 from webargs.flaskparser import use_args
 
-from ..util import get_dbstate, get_locale_for_language
+from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource, Resource
 from .emit import GrampsJSONEncoder
 from .filters import apply_filter
@@ -72,7 +72,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get_object_from_gramps_id(self, gramps_id: str) -> GrampsObject:
         """Get the object given a Gramps ID."""

--- a/gramps_webapi/api/resources/bookmarks.py
+++ b/gramps_webapi/api/resources/bookmarks.py
@@ -25,7 +25,7 @@ from typing import List, Optional
 from flask import Response, abort
 from gramps.gen.db.base import DbReadBase
 
-from ..util import get_dbstate
+from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -74,7 +74,7 @@ class BookmarkResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self, namespace: str) -> Response:
         """Get list of bookmarks by namespace."""
@@ -87,7 +87,7 @@ class BookmarksResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self) -> Response:
         """Get the list of bookmark types."""

--- a/gramps_webapi/api/resources/events.py
+++ b/gramps_webapi/api/resources/events.py
@@ -32,7 +32,7 @@ from webargs import fields, validate
 from webargs.flaskparser import use_args
 
 from ...types import Handle
-from ..util import get_dbstate, get_locale_for_language
+from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .base import (
     GrampsObjectProtectedResource,
@@ -80,7 +80,7 @@ class EventSpanResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     @use_args(
         {

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -49,7 +49,7 @@ from gramps.gen.utils.resourcepath import ResourcePath
 from webargs import fields, validate
 from webargs.flaskparser import use_args
 
-from ..util import get_buffer_for_file, get_dbstate, get_locale_for_language
+from ..util import get_buffer_for_file, get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -158,7 +158,7 @@ class ExportersResource(ProtectedResource, GrampsJSONEncoder):
     @use_args({}, location="query")
     def get(self, args: Dict) -> Response:
         """Get all available exporter attributes."""
-        db_handle = get_dbstate().db
+        db_handle = get_db_handle()
         return self.response(200, get_exporters())
 
 
@@ -168,7 +168,7 @@ class ExporterResource(ProtectedResource, GrampsJSONEncoder):
     @use_args({}, location="query")
     def get(self, args: Dict, extension: str) -> Response:
         """Get specific report attributes."""
-        db_handle = get_dbstate().db
+        db_handle = get_db_handle()
         exporters = get_exporters(extension)
         if exporters == []:
             abort(404)
@@ -218,7 +218,7 @@ class ExporterFileResource(ProtectedResource, GrampsJSONEncoder):
     )
     def get(self, args: Dict, extension: str) -> Response:
         """Get export file."""
-        db_handle = get_dbstate().db
+        db_handle = get_db_handle()
         exporters = get_exporters(extension)
         if exporters == []:
             abort(404)

--- a/gramps_webapi/api/resources/name_formats.py
+++ b/gramps_webapi/api/resources/name_formats.py
@@ -23,7 +23,7 @@
 from flask import Response
 from gramps.gen.db.base import DbReadBase
 
-from ..util import get_dbstate
+from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -34,7 +34,7 @@ class NameFormatsResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self) -> Response:
         """Get list of name formats."""

--- a/gramps_webapi/api/resources/name_groups.py
+++ b/gramps_webapi/api/resources/name_groups.py
@@ -23,7 +23,7 @@
 from flask import Response, abort
 from gramps.gen.db.base import DbReadBase
 
-from ..util import get_dbstate
+from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -34,7 +34,7 @@ class NameGroupsResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self, surname: str = None) -> Response:
         """Get list of name group mappings."""

--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -28,7 +28,7 @@ from webargs import fields, validate
 from webargs.flaskparser import use_args
 
 from ...types import Handle
-from ..util import get_dbstate, get_locale_for_language
+from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 from .util import get_person_by_handle
@@ -46,7 +46,7 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
     )
     def get(self, args: Dict, handle1: Handle, handle2: Handle) -> Response:
         """Get the most direct relationship between two people."""
-        db_handle = get_dbstate().db
+        db_handle = get_db_handle()
         person1 = get_person_by_handle(db_handle, handle1)
         if person1 == {}:
             abort(404)
@@ -82,7 +82,7 @@ class RelationsResource(ProtectedResource, GrampsJSONEncoder):
     )
     def get(self, args: Dict, handle1: Handle, handle2: Handle) -> Response:
         """Get all possible relationships between two people."""
-        db_handle = get_dbstate().db
+        db_handle = get_db_handle()
         person1 = get_person_by_handle(db_handle, handle1)
         if person1 == {}:
             abort(404)

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -38,7 +38,7 @@ from webargs import fields, validate
 from webargs.flaskparser import use_args
 
 from ...const import REPORT_DEFAULTS, REPORT_FILTERS
-from ..util import get_buffer_for_file, get_dbstate
+from ..util import get_buffer_for_file, get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -174,7 +174,7 @@ class ReportsResource(ProtectedResource, GrampsJSONEncoder):
     @use_args({}, location="query")
     def get(self, args: Dict) -> Response:
         """Get all available report attributes."""
-        reports = get_reports(get_dbstate().db)
+        reports = get_reports(get_db_handle())
         return self.response(200, reports)
 
 
@@ -184,7 +184,7 @@ class ReportResource(ProtectedResource, GrampsJSONEncoder):
     @use_args({}, location="query")
     def get(self, args: Dict, report_id: str) -> Response:
         """Get specific report attributes."""
-        reports = get_reports(get_dbstate().db, report_id=report_id)
+        reports = get_reports(get_db_handle(), report_id=report_id)
         if reports == []:
             abort(404)
         return self.response(200, reports[0])
@@ -194,10 +194,7 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
     """Report file resource."""
 
     @use_args(
-        {
-            "options": fields.Str(validate=validate.Length(min=1)),
-        },
-        location="query",
+        {"options": fields.Str(validate=validate.Length(min=1)),}, location="query",
     )
     def get(self, args: Dict, report_id: str) -> Response:
         """Get specific report attributes."""
@@ -210,6 +207,6 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
         if "of" in report_options:
             abort(422)
 
-        file_name, file_type = run_report(get_dbstate().db, report_id, report_options)
+        file_name, file_type = run_report(get_db_handle(), report_id, report_options)
         buffer = get_buffer_for_file(file_name)
         return send_file(buffer, mimetype=types_map[file_type])

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -28,7 +28,7 @@ from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from webargs import fields
 from webargs.flaskparser import use_args
 
-from ..util import get_dbstate
+from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -39,7 +39,7 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get_object_from_handle(self, handle: str, class_name: str) -> GrampsObject:
         """Get the object given a Gramps handle."""

--- a/gramps_webapi/api/resources/types.py
+++ b/gramps_webapi/api/resources/types.py
@@ -41,7 +41,7 @@ from gramps.gen.lib.urltype import UrlType
 from webargs import fields
 from webargs.flaskparser import use_args
 
-from ..util import get_dbstate
+from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -162,10 +162,7 @@ class DefaultTypesResource(ProtectedResource, GrampsJSONEncoder):
     """Default types resource."""
 
     @use_args(
-        {
-            "locale": fields.Boolean(missing=False),
-        },
-        location="query",
+        {"locale": fields.Boolean(missing=False),}, location="query",
     )
     def get(self, args: Dict) -> Response:
         """Return a list of available default types."""
@@ -179,10 +176,7 @@ class DefaultTypeResource(ProtectedResource, GrampsJSONEncoder):
     """Default type resource."""
 
     @use_args(
-        {
-            "locale": fields.Boolean(missing=False),
-        },
-        location="query",
+        {"locale": fields.Boolean(missing=False),}, location="query",
     )
     def get(self, args: Dict, datatype: str) -> Response:
         """Return a list of values for a default type."""
@@ -213,7 +207,7 @@ class CustomTypesResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self) -> Response:
         """Return a list of available custom types."""
@@ -229,7 +223,7 @@ class CustomTypeResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     def get(self, datatype: str) -> Response:
         """Return list of values for the custom type."""
@@ -245,13 +239,10 @@ class TypesResource(ProtectedResource, GrampsJSONEncoder):
     @property
     def db_handle(self) -> DbReadBase:
         """Get the database instance."""
-        return get_dbstate().db
+        return get_db_handle()
 
     @use_args(
-        {
-            "locale": fields.Boolean(missing=False),
-        },
-        location="query",
+        {"locale": fields.Boolean(missing=False),}, location="query",
     )
     def get(self, args: Dict) -> Response:
         """Return list of values for the custom type."""

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -26,13 +26,12 @@ from typing import BinaryIO
 
 from flask import abort, current_app, g
 from gramps.gen.const import GRAMPS_LOCALE
+from gramps.gen.db.base import DbReadBase
 from gramps.gen.utils.file import expand_media_path
 from gramps.gen.utils.grampslocale import GrampsLocale
 
-from ..dbmanager import DbState
 
-
-def get_dbstate() -> DbState:
+def get_db_handle() -> DbReadBase:
     """Open the database and get the current state.
 
     Called before every request.
@@ -40,12 +39,12 @@ def get_dbstate() -> DbState:
     dbmgr = current_app.config["DB_MANAGER"]
     if "dbstate" not in g:
         g.dbstate = dbmgr.get_db()
-    return g.dbstate
+    return g.dbstate.db
 
 
 def get_media_base_dir():
     """Get the media base directory set in the database."""
-    db = get_dbstate().db
+    db = get_db_handle()
     return expand_media_path(db.get_mediapath(), db)
 
 


### PR DESCRIPTION
The function `get_dbstate()` was almost always used as like this: `db_handle = get_dbstate().db`. So I now replaced it with a function that directly returns the handle.

The main reason for this change is to be able to return proxy DBs instead, to solve #95.

@cdhorn, the only non-trivial change is in metadata, which is the only place where the dbstate was used (not the db). But I replaced this with a fresh instance `DbState()` because I don't think it actually does anything that requires the DB; but it would be good if you could have a look to be sure.