### PR TITLE
Add place profile (fixes #104)

### DIFF
--- a/gramps_webapi/api/resources/places.py
+++ b/gramps_webapi/api/resources/places.py
@@ -21,17 +21,35 @@
 
 """Place API resource."""
 
+from typing import Dict
+
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.lib import Place
+from gramps.gen.utils.grampslocale import GrampsLocale
+
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
+from .util import get_place_profile_for_object
 
 
 class PlaceResourceHelper(GrampsObjectResourceHelper):
     """Place resource helper."""
 
     gramps_class_name = "Place"
+
+    def object_extend(
+        self, obj: Place, args: Dict, locale: GrampsLocale = glocale
+    ) -> Place:
+        """Extend place attributes as needed."""
+        db_handle = self.db_handle
+        if "profile" in args:
+            obj.profile = get_place_profile_for_object(
+                db_handle=db_handle, place=obj, locale=locale
+            )
+        return obj
 
 
 class PlaceResource(GrampsObjectProtectedResource, PlaceResourceHelper):

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -37,6 +37,7 @@ from gramps.gen.utils.db import (
     get_marriage_or_fallback,
 )
 from gramps.gen.utils.grampslocale import GrampsLocale
+from gramps.gen.utils.place import conv_lat_lon
 
 from ...const import SEX_FEMALE, SEX_MALE, SEX_UNKNOWN
 from ...types import Handle
@@ -191,6 +192,7 @@ def get_place_profile_for_object(
     parent_places: bool = True,
 ) -> Dict[str, Any]:
     """Get place profile given a Place."""
+    latitude, longitude = conv_lat_lon(place.lat, place.long, format="D.D8")
     profile = {
         "gramps_id": place.gramps_id,
         "type": _format_place_type(place.get_type(), locale=locale),
@@ -198,6 +200,8 @@ def get_place_profile_for_object(
         "alternative_names": [
             place_name.value for place_name in place.get_alternative_names()
         ],
+        "lat": float(latitude) if (latitude and longitude) else None,
+        "long": float(longitude) if (latitude and longitude) else None,
     }
     if parent_places:
         parent_places_handles = []

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -197,8 +197,8 @@ def get_place_profile_for_object(
         "gramps_id": place.gramps_id,
         "type": _format_place_type(place.get_type(), locale=locale),
         "name": place.get_name().value,
-        "alternative_names": [
-            place_name.value for place_name in place.get_alternative_names()
+        "alternate_names": [
+            place_name.value for place_name in place.get_alternate_names()
         ],
         "lat": float(latitude) if (latitude and longitude) else None,
         "long": float(longitude) if (latitude and longitude) else None,

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -20,15 +20,14 @@
 #
 
 """Gramps utility functions."""
-
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.display.name import NameDisplay
 from gramps.gen.display.place import PlaceDisplay
 from gramps.gen.errors import HandleError
-from gramps.gen.lib import Event, Family, Person, Place, Source, Span
+from gramps.gen.lib import Event, Family, Person, Place, PlaceType, Source, Span
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.soundex import soundex
 from gramps.gen.utils.db import (
@@ -176,6 +175,54 @@ def get_divorce_profile(
     if event is None:
         return {}, None
     return get_event_profile_for_object(db_handle, event, locale=locale), event
+
+
+def _format_place_type(
+    place_type: PlaceType, locale: GrampsLocale = glocale
+) -> Dict[str, Any]:
+    """Format a place type."""
+    return locale.translation.sgettext(place_type.xml_str())
+
+
+def get_place_profile_for_object(
+    db_handle: DbReadBase,
+    place: Place,
+    locale: GrampsLocale = glocale,
+    parent_places: bool = True,
+) -> Dict[str, Any]:
+    """Get place profile given a Place."""
+    profile = {
+        "gramps_id": place.gramps_id,
+        "type": _format_place_type(place.get_type(), locale=locale),
+        "name": place.get_name().value,
+        "alternative_names": [
+            place_name.value for place_name in place.get_alternative_names()
+        ],
+    }
+    if parent_places:
+        parent_places_handles = []
+        _place = place
+        handle = None
+        while True:
+            for placeref in _place.get_placeref_list():
+                handle = placeref.ref
+                break
+            if handle is None or handle in parent_places_handles:
+                break
+            _place = db_handle.get_place_from_handle(handle)
+            if _place is None:
+                break
+            parent_places_handles.append(handle)
+        profile["parent_places"] = [
+            get_place_profile_for_object(
+                db_handle=db_handle,
+                place=db_handle.get_place_from_handle(parent_place),
+                locale=locale,
+                parent_places=False,
+            )
+            for parent_place in parent_places_handles
+        ]
+    return profile
 
 
 def get_person_profile_for_object(

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -668,7 +668,7 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
-            age | Returns age at time of a personal event    
+            age | Returns age at time of a personal event
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
@@ -765,7 +765,7 @@ paths:
             Object | Contents
             ------ | --------
             all | Returns all information below
-            age | Returns age at time of a personal event    
+            age | Returns age at time of a personal event
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
@@ -1199,6 +1199,18 @@ paths:
             note_list | The list of note records
             tag_list | The list of tags
             backlinks | The lists of backlinks per object type
+      - name: profile
+        in: query
+        required: false
+        type: string
+        description: >
+          Enables the return of summarized information about the place in a more readily consumable format. This additional information is returned under the top level 'profile' keyword in the response.
+
+
+          Accepts a comma delimited list of possible objects to be provided. For events the possible objects are:
+            Object | Contents
+            ------ | --------
+            all | Returns all information
       responses:
         200:
           description: "OK: Successful operation."
@@ -4646,6 +4658,11 @@ definitions:
         description: "Private object indicator."
         type: boolean
         example: false
+      profile:
+        description: "An optional summary of the parent places and geo coordinates."
+        type: object
+        items:
+          $ref: "#/definitions/PlaceProfile"
       tag_list:
         description: "A list of handles to tags associated with the place."
         type: array
@@ -4735,6 +4752,45 @@ definitions:
         description: "Handle of the referenced place."
         type: string
         example: "c965872719e5db6bfe5fc47b033"
+
+
+##############################################################################
+# Model - PlaceProfile
+##############################################################################
+
+  PlaceProfile:
+    type: object
+    properties:
+      alternate_names:
+        description: "Alternative names of the place."
+        type: array
+        items:
+          type: string
+        example:
+          - "Gainesville, FA"
+      gramps_id:
+        description: "The place's Gramps ID."
+        type: string
+        example: P0001
+      lat:
+        description: "The geographic latitude as a float."
+        type: number
+        example: 33.6259414
+      long:
+        description: "The geographic longitude as a float."
+        type: number
+        example: -97.1333453
+      name:
+        description: "The place title."
+        type: string
+        example: Gainesville
+      parent_places:
+        description: "A list of parent places."
+        type: array
+        items:
+          $ref: "#/definitions/PlaceProfile"
+
+
 
 ##############################################################################
 # Model - Address

--- a/tests/test_endpoints/test_places.py
+++ b/tests/test_endpoints/test_places.py
@@ -173,17 +173,13 @@ class TestPlacesHandle(unittest.TestCase):
     def test_places_handle_endpoint_keys(self):
         """Test response for keys parm."""
         run_test_endpoint_keys(
-            self,
-            "/api/places/09UJQCF3TNGH9GU0P1",
-            ["handle", "lat", "long"],
+            self, "/api/places/09UJQCF3TNGH9GU0P1", ["handle", "lat", "long"],
         )
 
     def test_places_handle_endpoint_skipkeys(self):
         """Test response for skipkeys parm."""
         run_test_endpoint_skipkeys(
-            self,
-            "/api/places/09UJQCF3TNGH9GU0P1",
-            ["handle", "media_list", "private"],
+            self, "/api/places/09UJQCF3TNGH9GU0P1", ["handle", "media_list", "private"],
         )
 
     def test_places_handle_endpoint_extend(self):
@@ -206,3 +202,36 @@ class TestPlacesHandle(unittest.TestCase):
             schema=API_SCHEMA["definitions"]["Place"],
             resolver=resolver,
         )
+
+    def test_places_profile(self):
+        result = self.client.get("/api/places/08TJQCCFIX31BXPNXN?profile=all&locale=it")
+        self.assertEqual(
+            result.json["profile"],
+            {
+                "alternative_names": [],
+                "gramps_id": "P0860",
+                "name": "Gainesville",
+                "parent_places": [
+                    {
+                        "alternative_names": [],
+                        "gramps_id": "P0194",
+                        "name": "Llano",
+                        "type": "Contea",
+                    },
+                    {
+                        "alternative_names": [],
+                        "gramps_id": "P0010",
+                        "name": "TX",
+                        "type": "Stato (federato)",
+                    },
+                    {
+                        "alternative_names": [],
+                        "gramps_id": "P0957",
+                        "name": "USA",
+                        "type": "Nazione",
+                    },
+                ],
+                "type": "Città",
+            },
+        )
+

--- a/tests/test_endpoints/test_places.py
+++ b/tests/test_endpoints/test_places.py
@@ -210,23 +210,31 @@ class TestPlacesHandle(unittest.TestCase):
             {
                 "alternative_names": [],
                 "gramps_id": "P0860",
+                "lat": 33.6259414,
+                "long": -97.1333453,
                 "name": "Gainesville",
                 "parent_places": [
                     {
                         "alternative_names": [],
                         "gramps_id": "P0194",
+                        "lat": None,
+                        "long": None,
                         "name": "Llano",
                         "type": "Contea",
                     },
                     {
                         "alternative_names": [],
                         "gramps_id": "P0010",
+                        "lat": None,
+                        "long": None,
                         "name": "TX",
                         "type": "Stato (federato)",
                     },
                     {
                         "alternative_names": [],
                         "gramps_id": "P0957",
+                        "lat": None,
+                        "long": None,
                         "name": "USA",
                         "type": "Nazione",
                     },

--- a/tests/test_endpoints/test_places.py
+++ b/tests/test_endpoints/test_places.py
@@ -208,14 +208,14 @@ class TestPlacesHandle(unittest.TestCase):
         self.assertEqual(
             result.json["profile"],
             {
-                "alternative_names": [],
+                "alternate_names": [],
                 "gramps_id": "P0860",
                 "lat": 33.6259414,
                 "long": -97.1333453,
                 "name": "Gainesville",
                 "parent_places": [
                     {
-                        "alternative_names": [],
+                        "alternate_names": [],
                         "gramps_id": "P0194",
                         "lat": None,
                         "long": None,
@@ -223,7 +223,7 @@ class TestPlacesHandle(unittest.TestCase):
                         "type": "Contea",
                     },
                     {
-                        "alternative_names": [],
+                        "alternate_names": [],
                         "gramps_id": "P0010",
                         "lat": None,
                         "long": None,
@@ -231,7 +231,7 @@ class TestPlacesHandle(unittest.TestCase):
                         "type": "Stato (federato)",
                     },
                     {
-                        "alternative_names": [],
+                        "alternate_names": [],
                         "gramps_id": "P0957",
                         "lat": None,
                         "long": None,


### PR DESCRIPTION
Looking into this, I realized again how complex places are in Gramps (even before more possible complications coming in 5.2). They can have multiple names in different languages and valid at different times; they can have multiple parents and multiple children in the hierarchy.

This PR is just a simplistic version which ignores the time dependence. It only returns the place hierarchy for the most recent names. Further details could be added later.

For an example of what this looks like, see the added unit test.

Still need to add the docs.