### PR TITLE
Fix regression in place profile

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -198,7 +198,7 @@ def get_place_profile_for_object(
         "type": _format_place_type(place.get_type(), locale=locale),
         "name": place.get_name().value,
         "alternate_names": [
-            place_name.value for place_name in place.get_alternate_names()
+            place_name.value for place_name in place.get_alternative_names()
         ],
         "lat": float(latitude) if (latitude and longitude) else None,
         "long": float(longitude) if (latitude and longitude) else None,


### PR DESCRIPTION
I made a silly mistake, changing `alternative_names` to `alternate_names` to be more consistent with the people profile in #104, but accidentally also renamed a method that is actually called `get_alternative_names` in `gramps`.