### PR TITLE
Fix unit tests (fixes #120)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -24,7 +24,7 @@ from typing import Type
 
 from flask import Blueprint, current_app
 from webargs import fields, validate
-from webargs.flaskparser import use_args
+from webargs.flaskparser import FlaskParser
 
 from ..const import API_PREFIX
 from .auth import jwt_required_ifauth
@@ -68,6 +68,16 @@ from .resources.user import (
     UserResetPasswordResource,
     UserTriggerResetPasswordResource,
 )
+
+
+class Parser(FlaskParser):
+    # raise in case of unknown query arguments
+    DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
+
+
+parser = Parser()
+use_args = parser.use_args
+
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
 

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -24,7 +24,6 @@ from typing import Type
 
 from flask import Blueprint, current_app
 from webargs import fields, validate
-from webargs.flaskparser import FlaskParser
 
 from ..const import API_PREFIX
 from .auth import jwt_required_ifauth
@@ -68,16 +67,7 @@ from .resources.user import (
     UserResetPasswordResource,
     UserTriggerResetPasswordResource,
 )
-
-
-class Parser(FlaskParser):
-    # raise in case of unknown query arguments
-    DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
-
-
-parser = Parser()
-use_args = parser.use_args
-
+from .util import use_args
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
 

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -31,21 +31,14 @@ from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.utils.grampslocale import GrampsLocale
 from marshmallow import RAISE
 from webargs import fields, validate
-from webargs.flaskparser import FlaskParser
 
+from .. import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource, Resource
 from .emit import GrampsJSONEncoder
 from .filters import apply_filter
 from .sort import sort_objects
 from .util import get_backlinks, get_extended_attributes, get_soundex
-
-
-class Parser(FlaskParser):
-    DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
-
-
-PARSER = Parser()
 
 
 class GrampsObjectResourceHelper(GrampsJSONEncoder):
@@ -108,7 +101,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
 class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
     """Resource for a single object."""
 
-    @PARSER.use_args(
+    @use_args(
         {
             "backlinks": fields.Boolean(missing=False),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
@@ -144,7 +137,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
     """Resource for multiple objects."""
 
-    @PARSER.use_args(
+    @use_args(
         {
             "backlinks": fields.Boolean(missing=False),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -29,10 +29,9 @@ from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.utils.grampslocale import GrampsLocale
-from marshmallow import RAISE
 from webargs import fields, validate
 
-from .. import use_args
+from ..util import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource, Resource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -29,8 +29,9 @@ from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.utils.grampslocale import GrampsLocale
+from marshmallow import RAISE
 from webargs import fields, validate
-from webargs.flaskparser import use_args
+from webargs.flaskparser import FlaskParser
 
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource, Resource
@@ -38,6 +39,13 @@ from .emit import GrampsJSONEncoder
 from .filters import apply_filter
 from .sort import sort_objects
 from .util import get_backlinks, get_extended_attributes, get_soundex
+
+
+class Parser(FlaskParser):
+    DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
+
+
+PARSER = Parser()
 
 
 class GrampsObjectResourceHelper(GrampsJSONEncoder):
@@ -100,7 +108,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
 class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
     """Resource for a single object."""
 
-    @use_args(
+    @PARSER.use_args(
         {
             "backlinks": fields.Boolean(missing=False),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
@@ -136,7 +144,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
     """Resource for multiple objects."""
 
-    @use_args(
+    @PARSER.use_args(
         {
             "backlinks": fields.Boolean(missing=False),
             "extend": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),

--- a/gramps_webapi/api/resources/events.py
+++ b/gramps_webapi/api/resources/events.py
@@ -32,7 +32,7 @@ from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
 
 from ...types import Handle
-from .. import use_args
+from ..util import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .base import (

--- a/gramps_webapi/api/resources/events.py
+++ b/gramps_webapi/api/resources/events.py
@@ -30,9 +30,9 @@ from gramps.gen.errors import HandleError
 from gramps.gen.lib import Event, Span
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
-from webargs.flaskparser import use_args
 
 from ...types import Handle
+from .. import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .base import (

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -48,7 +48,7 @@ from gramps.gen.user import User
 from gramps.gen.utils.resourcepath import ResourcePath
 from webargs import fields, validate
 
-from .. import use_args
+from ..util import use_args
 from ..util import get_buffer_for_file, get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -47,8 +47,8 @@ from gramps.gen.proxy import (
 from gramps.gen.user import User
 from gramps.gen.utils.resourcepath import ResourcePath
 from webargs import fields, validate
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from ..util import get_buffer_for_file, get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -29,8 +29,8 @@ from gramps.gen.db.base import DbReadBase
 from gramps.gen.filters import GenericFilter
 from marshmallow import Schema
 from webargs import ValidationError, fields, validate
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from ...const import GRAMPS_NAMESPACES
 from ...types import Handle
 from . import ProtectedResource
@@ -193,8 +193,7 @@ class FiltersResources(ProtectedResource, GrampsJSONEncoder):
     """Filters resources."""
 
     @use_args(
-        {},
-        location="query",
+        {}, location="query",
     )
     def get(self, args: Dict[str, str]) -> Response:
         """Get available custom filters and rules."""
@@ -288,10 +287,7 @@ class FilterResource(ProtectedResource, GrampsJSONEncoder):
         return self.response(200, filter_list[0])
 
     @use_args(
-        {
-            "force": fields.Str(validate=validate.Length(equal=0)),
-        },
-        location="query",
+        {"force": fields.Str(validate=validate.Length(equal=0)),}, location="query",
     )
     def delete(self, args: Dict, namespace: str, name: str) -> Response:
         """Delete a custom filter."""

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -30,7 +30,7 @@ from gramps.gen.filters import GenericFilter
 from marshmallow import Schema
 from webargs import ValidationError, fields, validate
 
-from .. import use_args
+from ..util import use_args
 from ...const import GRAMPS_NAMESPACES
 from ...types import Handle
 from . import ProtectedResource

--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -25,9 +25,9 @@ from typing import Dict
 from flask import Response, abort
 from gramps.gen.relationship import get_relationship_calculator
 from webargs import fields, validate
-from webargs.flaskparser import use_args
 
 from ...types import Handle
+from .. import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -27,7 +27,7 @@ from gramps.gen.relationship import get_relationship_calculator
 from webargs import fields, validate
 
 from ...types import Handle
-from .. import use_args
+from ..util import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -37,7 +37,7 @@ from gramps.gen.utils.resourcepath import ResourcePath
 from webargs import fields, validate
 
 from ...const import REPORT_DEFAULTS, REPORT_FILTERS
-from .. import use_args
+from ..util import use_args
 from ..util import get_buffer_for_file, get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -35,9 +35,9 @@ from gramps.gen.filters import reload_custom_filters
 from gramps.gen.plug import BasePluginManager
 from gramps.gen.utils.resourcepath import ResourcePath
 from webargs import fields, validate
-from webargs.flaskparser import use_args
 
 from ...const import REPORT_DEFAULTS, REPORT_FILTERS
+from .. import use_args
 from ..util import get_buffer_for_file, get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -28,7 +28,7 @@ from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
 
-from .. import use_args
+from ..util import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -27,8 +27,8 @@ from gramps.gen.db.base import DbReadBase
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
@@ -97,4 +97,4 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
                     args=args,
                     locale=locale,
                 )
-        return self.response(200, payload=hits, args=args, total_items=total)
+        return self.response(200, payload=hits or [], args=args, total_items=total)

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -31,8 +31,8 @@ from flask_jwt_extended import (
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from webargs import fields
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from . import RefreshProtectedResource, Resource
 
 limiter = Limiter(key_func=get_remote_address)

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -32,7 +32,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from webargs import fields
 
-from .. import use_args
+from ..util import use_args
 from . import RefreshProtectedResource, Resource
 
 limiter = Limiter(key_func=get_remote_address)

--- a/gramps_webapi/api/resources/translations.py
+++ b/gramps_webapi/api/resources/translations.py
@@ -28,8 +28,8 @@ from flask import Response, abort
 from gramps.gen.const import GRAMPS_LOCALE
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -38,8 +38,7 @@ class TranslationResource(ProtectedResource, GrampsJSONEncoder):
     """Translation resource."""
 
     @use_args(
-        {"strings": fields.Str(required=True)},
-        location="query",
+        {"strings": fields.Str(required=True)}, location="query",
     )
     def get(self, args: Dict, language: str) -> Response:
         """Get translation."""

--- a/gramps_webapi/api/resources/translations.py
+++ b/gramps_webapi/api/resources/translations.py
@@ -29,7 +29,7 @@ from gramps.gen.const import GRAMPS_LOCALE
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields
 
-from .. import use_args
+from ..util import use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 

--- a/gramps_webapi/api/resources/types.py
+++ b/gramps_webapi/api/resources/types.py
@@ -39,8 +39,8 @@ from gramps.gen.lib.srcattrtype import SrcAttributeType
 from gramps.gen.lib.srcmediatype import SourceMediaType
 from gramps.gen.lib.urltype import UrlType
 from webargs import fields
-from webargs.flaskparser import use_args
 
+from .. import use_args
 from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/types.py
+++ b/gramps_webapi/api/resources/types.py
@@ -40,7 +40,7 @@ from gramps.gen.lib.srcmediatype import SourceMediaType
 from gramps.gen.lib.urltype import UrlType
 from webargs import fields
 
-from .. import use_args
+from ..util import use_args
 from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -27,9 +27,9 @@ from flask_jwt_extended import create_access_token, get_jwt_claims, get_jwt_iden
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from webargs import fields
-from webargs.flaskparser import use_args
 
 from ...auth.const import PERM_EDIT_OWN_USER
+from .. import use_args
 from ..auth import require_permissions
 from ..util import send_email
 from . import ProtectedResource, Resource

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -29,7 +29,7 @@ from flask_limiter.util import get_remote_address
 from webargs import fields
 
 from ...auth.const import PERM_EDIT_OWN_USER
-from .. import use_args
+from ..util import use_args
 from ..auth import require_permissions
 from ..util import send_email
 from . import ProtectedResource, Resource

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -33,9 +33,20 @@ from gramps.gen.db.base import DbReadBase
 from gramps.gen.proxy import PrivateProxyDb
 from gramps.gen.utils.file import expand_media_path
 from gramps.gen.utils.grampslocale import GrampsLocale
+from marshmallow import RAISE
+from webargs.flaskparser import FlaskParser
 
 from ..auth.const import PERM_VIEW_PRIVATE
 from .auth import has_permissions
+
+
+class Parser(FlaskParser):
+    # raise in case of unknown query arguments
+    DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
+
+
+parser = Parser()
+use_args = parser.use_args
 
 
 class ModifiedPrivateProxyDb(PrivateProxyDb):


### PR DESCRIPTION
I believe this fixes #120. I subclassed `webargs.FlaskParser` (as per the documentation) to make unknown query arguments fail with a 422. This is tested in some of the tests and does not happen by default anymore in webargs 7. This should also be backwards compatible as it only sets a class attribute on the subclass.

The only failing test is Python 3.5 due to #114, but we might get rid of it anyway...