### PR TITLE
Add new database manager class (fixes #16)

### DIFF
--- a/gramps_webapi/__main__.py
+++ b/gramps_webapi/__main__.py
@@ -44,8 +44,7 @@ def cli(ctx, config):
 def run(ctx, port):
     """Run the app."""
     app = ctx.obj
-    # threading is disabled to avoid problems with locked databases
-    app.run(port=port, threaded=False)
+    app.run(port=port, threaded=True)
 
 
 @cli.group("user")

--- a/gramps_webapi/dbloader.py
+++ b/gramps_webapi/dbloader.py
@@ -1,0 +1,148 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2001-2006  Donald N. Allingham
+# Copyright (C) 2009 Benny Malengier
+# Copyright (C) 2020 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Database loader utilitis derived from `grampscli`."""
+
+import logging
+import os
+
+from gramps.gen.config import config
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.const import PLUGINS_DIR, USER_PLUGINS
+from gramps.gen.db.dbconst import DBBACKEND, DBLOCKFN, DBMODE_R, DBMODE_W
+from gramps.gen.db.utils import make_database
+from gramps.gen.dbstate import DbState
+from gramps.gen.display.name import displayer as name_displayer
+from gramps.gen.plug import BasePluginManager
+from gramps.gen.recentfiles import recent_files
+from gramps.gen.utils.config import get_researcher
+
+
+_ = glocale.translation.gettext
+
+LOG = logging.getLogger(__name__)
+
+
+class DbLockedError(Exception):
+    """Exception raised when a db is locked and write access is requested."""
+
+
+def check_lock(dir_name: str, mode: str):
+    """Raise if the mode is 'w' and the database is locked."""
+    if mode == DBMODE_W and os.path.isfile(os.path.join(dir_name, DBLOCKFN)):
+        raise DbLockedError(_("The database is locked."))
+
+
+def get_title(filename: str) -> str:
+    """Get the database title."""
+    path = os.path.join(filename, "name.txt")
+    try:
+        with open(path, encoding="utf8") as ifile:
+            title = ifile.readline().strip()
+    except FileNotFoundError:
+        title = filename
+    return title
+
+
+class WebDbSessionManager:
+    """Session manager derived from `CLIDbLoader` and `CLIManager`."""
+
+    def __init__(self, dbstate: DbState, user):
+        """Initialize self."""
+        self.dbstate = dbstate
+        self._pmgr = BasePluginManager.get_instance()
+        self.user = user
+
+    def read_file(self, filename, mode: str, username: str, password: str):
+        """Open a database from a file."""
+        if (
+            mode == DBMODE_W
+            and os.path.exists(filename)
+            and not os.access(filename, os.W_OK)
+        ):
+            mode = DBMODE_R
+            LOG.warning(
+                "%s. %s",
+                _("Read only database"),
+                _("You do not have write access " "to the selected file."),
+            )
+
+        dbid_path = os.path.join(filename, DBBACKEND)
+        with open(dbid_path) as file_handle:
+            dbid = file_handle.read().strip()
+
+        db = make_database(dbid)
+
+        self.dbstate.change_database(db)
+        self.dbstate.db.disable_signals()
+
+        self.dbstate.db.load(
+            filename, callback=None, mode=mode, username=username, password=password,
+        )
+
+    def open_activate(self, filename, mode, username=None, password=None):
+        """Open and make a family tree active."""
+        check_lock(dir_name=filename, mode=mode)
+        self.read_file(filename, mode, username, password)
+        # Attempt to figure out the database title
+        title = get_title(filename)
+        self._post_load_newdb(filename, title)
+
+    def _post_load_newdb(self, filename, title=None):
+        """Called after load of a new database."""
+        if not filename:
+            return
+
+        if filename[-1] == os.path.sep:
+            filename = filename[:-1]
+        name = os.path.basename(filename)
+        self.dbstate.db.db_name = title
+        if title:
+            name = title
+
+        # apply preferred researcher if loaded file has none
+        res = self.dbstate.db.get_researcher()
+        owner = get_researcher()
+        # If the DB Owner Info is empty and
+        # [default] Researcher is not empty and
+        # database is empty, then copy default researcher to DB owner
+        if res.is_empty() and not owner.is_empty() and self.dbstate.db.get_total() == 0:
+            self.dbstate.db.set_researcher(owner)
+
+        name_displayer.clear_custom_formats()
+        name_displayer.set_name_format(self.dbstate.db.name_formats)
+        fmt_default = config.get("preferences.name-format")
+        name_displayer.set_default_format(fmt_default)
+
+        self.dbstate.db.enable_signals()
+        self.dbstate.signal_change()
+
+        config.set("paths.recent-file", filename)
+
+        recent_files(filename, name)
+
+    def do_reg_plugins(self, dbstate, uistate, rescan=False):
+        """Register the plugins at initialization time."""
+        self._pmgr.reg_plugins(PLUGINS_DIR, dbstate, uistate, rescan=rescan)
+        self._pmgr.reg_plugins(USER_PLUGINS, dbstate, uistate, load_on_reg=True)
+        if rescan:  # supports updated plugin installs
+            self._pmgr.reload_plugins()

--- a/gramps_webapi/dbmanager.py
+++ b/gramps_webapi/dbmanager.py
@@ -23,11 +23,12 @@
 import os
 
 from gramps.cli.clidbman import CLIDbManager
-from gramps.cli.grampscli import CLIManager
 from gramps.cli.user import User
-from gramps.gen.db.dbconst import DBLOCKFN
+from gramps.gen.db.dbconst import DBLOCKFN, DBMODE_R, DBMODE_W
 from gramps.gen.db.utils import get_dbid_from_path
 from gramps.gen.dbstate import DbState
+
+from .dbloader import WebDbSessionManager
 
 
 class WebDbManager:
@@ -71,16 +72,18 @@ class WebDbManager:
         if os.path.exists(os.path.join(self.path, DBLOCKFN)):
             os.unlink(os.path.join(self.path, DBLOCKFN))
 
-    def get_db(self, force_unlock: bool = False) -> DbState:
+    def get_db(self, lock: bool = False, force_unlock: bool = False) -> DbState:
         """Open the database and return a dbstate instance.
 
+        If `lock` is `False`, will not write a lock file (use with care!).
         If `force_unlock` is `True`, will break an existing lock (use with care!).
         """
         dbstate = DbState()
         user = User()
-        smgr = CLIManager(dbstate, True, user)
+        smgr = WebDbSessionManager(dbstate, user)
         smgr.do_reg_plugins(dbstate, uistate=None)
         if force_unlock:
             self.break_lock()
-        smgr.open_activate(self.path)
+        mode = DBMODE_W if lock else DBMODE_R
+        smgr.open_activate(self.path, mode=mode)
         return dbstate

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -46,7 +46,11 @@ class TestWebDbManager(unittest.TestCase):
         """Test if db is locked while open."""
         dbmgr = WebDbManager(self.name)
         self.assertFalse(dbmgr.is_locked())
-        dbstate = dbmgr.get_db()
+        dbstate = dbmgr.get_db(lock=True)
         self.assertTrue(dbmgr.is_locked())
+        dbstate.db.close()
+        self.assertFalse(dbmgr.is_locked())
+        dbstate = dbmgr.get_db(lock=False)
+        self.assertFalse(dbmgr.is_locked())
         dbstate.db.close()
         self.assertFalse(dbmgr.is_locked())


### PR DESCRIPTION
Since the PR https://github.com/gramps-project/gramps/pull/1119 seems to have stalled (and indeed I'm not sure anymore this is the best way to solve it), I went ahead and added a new DB manager class that is a combination of Gramps's `CliDbManager` and `CliManager` classes; however it is *much* more concise since we can get rid of all the error handling. It's not necessary since any error raised during the handling of the database will simply cause a 500 Server Error in flask, which is the appropriate response (but the server will not crash).

What it provides in the end is a boolean argument on `get_db` that allows to disable writing a lock file. This is disabled by default now, since we are not writing anything to the DB yet anyway. In the future, we can decide whether a given operation should write a lock file (prevent all other uses from writing to the DB). My guess is that we'll end up locking the DB for most `PUT` request (which modify a resource, and we want to prevent conflicting modifications), while I believe we can omit locking for most `POST` requests (that add a new resource), since adding a new object to the DB cannot lead to a conflict (they are unique thanks to their handle).

Anyway, for the moment all this does is fix #16: we can now run the web server with multiple threads/processes (which is badly needed for a multi-user application).