### PR TITLE
Fix total size

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -236,6 +236,8 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
         if "sort" in args:
             handles = self.sort_objects(handles, args["sort"], locale=locale)
 
+        total_items = len(handles)
+
         if args["page"] > 0:
             offset = (args["page"] - 1) * args["pagesize"]
             handles = handles[offset : offset + args["pagesize"]]
@@ -250,7 +252,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
                 for handle in handles
             ],
             args,
-            total_items=len(handles),
+            total_items=total_items,
         )
 
 


### PR DESCRIPTION
That's a mini-PR ... I noticed that the `X-Total-Size` header was wrong for all endpoints since the length of the handle list was taken after applying the pagination, so it was always equal to the page size. I simply moved it up.