### PR TITLE
Improvements to search (fixes #110, fixes #111, fixes #130)

### DIFF
--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Tuple
 
 from gramps.gen.db.base import DbReadBase
+from gramps.gen.lib import Name
 from whoosh import index
 from whoosh.fields import ID, TEXT, Schema
 from whoosh.qparser import QueryParser
@@ -40,6 +41,11 @@ def object_to_string(obj):
     for child_obj in obj.get_text_data_child_list():
         if hasattr(child_obj, "get_text_data_list"):
             strings += child_obj.get_text_data_list()
+            if isinstance(child_obj, Name):
+                # for names, need to iterate one level deeper to also find surnames
+                for grandchild_obj in child_obj.get_text_data_child_list():
+                    if hasattr(grandchild_obj, "get_text_data_list"):
+                        strings += grandchild_obj.get_text_data_list()
     # discard duplicate strings but keep order
     strings = OrderedDict.fromkeys(strings)
     return " ".join(strings)

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -38,6 +38,8 @@ from ..types import FilenameOrPath, Handle
 def object_to_string(obj):
     """Create a string from a Gramps object's textual pieces."""
     strings = obj.get_text_data_list()
+    if hasattr(obj, "gramps_id") and obj.gramps_id not in strings:
+        strings.append(obj.gramps_id)
     for child_obj in obj.get_text_data_child_list():
         if hasattr(child_obj, "get_text_data_list"):
             strings += child_obj.get_text_data_list()

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -74,7 +74,7 @@ def create_app(db_manager=None):
     try:
         app.config["SEARCH_INDEXER"].reindex_full(db)
     except:
-        app.logger.exception()
+        app.logger.exception("Error during indexing")
     finally:
         db.close()
     app.logger.info("Done building search index.")

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -71,10 +71,13 @@ class TestSearchEngine(unittest.TestCase):
 
     def test_search_method(self):
         """Test search engine returns an expected result."""
-        total, rv = self.search.search("Abigail", page=1, pagesize=2)
+        total, rv = self.search.search("Lewis von", page=1, pagesize=2)
         self.assertEqual(
             {(hit["object_type"], hit["handle"]) for hit in rv},
-            {("person", "1QTJQCP5QMT2X7YJDK"), ("person", "APWKQCI6YXAXBLC33I"),},
+            {
+                ("person", "GNUJQCL9MD64AM56OH"),
+                ("note", "d0436be64ac277b615b79b34e72"),
+            },
         )
 
 
@@ -169,10 +172,10 @@ class TestSearch(unittest.TestCase):
 
     def test_get_search_parameter_profile_expected_result(self):
         """Test expected response."""
-        rv = check_success(self, TEST_URL + "?query=Abigail&page=1&profile=all")
+        rv = check_success(self, TEST_URL + "?query=Lewis%20von&page=1&profile=all")
         self.assertEqual(rv[0]["object_type"], "person")
         self.assertIn("profile", rv[0]["object"])
-        self.assertEqual(rv[0]["object"]["profile"]["name_given"], "Abigail")
+        self.assertEqual(rv[0]["object"]["profile"]["name_given"], "Lewis Anderson")
 
     def test_get_search_parameter_locale_validate_semantics(self):
         """Test invalid locale parameter and values."""
@@ -182,10 +185,10 @@ class TestSearch(unittest.TestCase):
 
     def test_get_search_parameter_profile_expected_result_with_locale(self):
         """Test expected profile response for a locale."""
-        rv = check_success(self, TEST_URL + "?query=Abigail&profile=self&locale=de")
+        rv = check_success(self, TEST_URL + "?query=Lewis%20von&profile=self&locale=de")
         self.assertEqual(rv[0]["object_type"], "person")
         self.assertIn("profile", rv[0]["object"])
-        self.assertEqual(rv[0]["object"]["profile"]["name_given"], "Abigail")
+        self.assertEqual(rv[0]["object"]["profile"]["name_given"], "Lewis Anderson")
         self.assertEqual(rv[0]["object"]["profile"]["birth"]["type"], "Geburt")
         self.assertEqual(rv[0]["object"]["profile"]["death"]["type"], "Tod")
 

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -23,8 +23,10 @@
 import shutil
 import tempfile
 import unittest
+from urllib.parse import quote
 
 from gramps_webapi.api.search import SearchIndexer
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 
 from . import BASE_URL, get_test_client
 from .checks import (
@@ -33,6 +35,7 @@ from .checks import (
     check_strip_parameter,
     check_success,
 )
+from .util import fetch_header
 
 TEST_URL = BASE_URL + "/search/"
 
@@ -71,10 +74,7 @@ class TestSearchEngine(unittest.TestCase):
         total, rv = self.search.search("Abigail", page=1, pagesize=2)
         self.assertEqual(
             {(hit["object_type"], hit["handle"]) for hit in rv},
-            {
-                ("person", "1QTJQCP5QMT2X7YJDK"),
-                ("person", "APWKQCI6YXAXBLC33I"),
-            },
+            {("person", "1QTJQCP5QMT2X7YJDK"), ("person", "APWKQCI6YXAXBLC33I"),},
         )
 
 
@@ -99,10 +99,10 @@ class TestSearch(unittest.TestCase):
         """Test expected result querying for text."""
         rv = check_success(self, TEST_URL + "?query=microfilm")
         self.assertEqual(
-            [hit["handle"] for hit in rv],
-            ["b39fe2e143d1e599450", "b39fe3f390e30bd2b99"],
+            {hit["handle"] for hit in rv},
+            {"b39fe2e143d1e599450", "b39fe3f390e30bd2b99"},
         )
-        self.assertEqual(rv[0]["object_type"], "note")
+        self.assertIn(rv[0]["object_type"], ["source", "note"])
         self.assertEqual(rv[0]["rank"], 0)
         self.assertIsInstance(rv[0]["score"], float)
 
@@ -139,8 +139,7 @@ class TestSearch(unittest.TestCase):
         )
         self.assertEqual(len(rv.json), 1)
         self.assertEqual(
-            [hit["handle"] for hit in rv.json],
-            ["b39fe2e143d1e599450"],
+            [hit["handle"] for hit in rv.json], ["b39fe3f390e30bd2b99"],
         )
         count = rv.headers.pop("X-Total-Count")
         self.assertEqual(count, "2")
@@ -149,8 +148,7 @@ class TestSearch(unittest.TestCase):
         )
         self.assertEqual(len(rv.json), 1)
         self.assertEqual(
-            [hit["handle"] for hit in rv.json],
-            ["b39fe3f390e30bd2b99"],
+            [hit["handle"] for hit in rv.json], ["b39fe2e143d1e599450"],
         )
         count = rv.headers.pop("X-Total-Count")
         self.assertEqual(count, "2")
@@ -190,3 +188,51 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(rv[0]["object"]["profile"]["name_given"], "Abigail")
         self.assertEqual(rv[0]["object"]["profile"]["birth"]["type"], "Geburt")
         self.assertEqual(rv[0]["object"]["profile"]["death"]["type"], "Tod")
+
+    def test_get_search_private_attribute_guest(self):
+        """Search for a private attribute as owner."""
+        header = fetch_header(self.client, role=ROLE_GUEST)
+        # the guest won't find any results when searching for the private attribute
+        rv = self.client.get(TEST_URL + "?query=123-456-7890", headers=header)
+        self.assertEqual(len(rv.json), 0)
+        rv = self.client.get(
+            TEST_URL + "?query=text_private:123-456-7890", headers=header
+        )
+        self.assertEqual(len(rv.json), 0)
+
+    def test_get_search_private_attribute_owner(self):
+        """Search for a private attribute as owner."""
+        header = fetch_header(self.client, role=ROLE_OWNER)
+        # the owner will get a hit when searching for the private attribute
+        rv = self.client.get(TEST_URL + "?query=123-456-7890", headers=header)
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0044")
+        rv = self.client.get(
+            TEST_URL + "?query=text_private:123-456-7890", headers=header
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0044")
+        rv = self.client.get(TEST_URL + "?query=text:123-456-7890", headers=header)
+        self.assertEqual(len(rv.json), 0)
+
+    def test_get_search_explicit_fields_owner(self):
+        """Search for a private attribute as owner."""
+        header = fetch_header(self.client, role=ROLE_OWNER)
+        rv = self.client.get(
+            TEST_URL
+            + "?query={}".format(quote("type:repository changed:'2012 to now'")),
+            headers=header,
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "R0002")
+
+    def test_get_search_explicit_fields_guest(self):
+        """Search for a private attribute as owner."""
+        header = fetch_header(self.client, role=ROLE_GUEST)
+        rv = self.client.get(
+            TEST_URL
+            + "?query={}".format(quote("type:repository changed:'2012 to now'")),
+            headers=header,
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "R0002")


### PR DESCRIPTION
This makes some improvments to full-text search and solved some existing issues.

- The issue #110 that Gramps IDs are not indexed for repos and notes is solved and a "forward-compatible" way by explicitly checking if an object's Gramps ID is part of the text data list or not, and is added if not
- The issue #130 that surnames cannot be searched for is solved by iterating one level further in child objects in case of `Name`s
- The issue #111 that private should not be searchable for unauthorized users is solved in a twofold way:
  - A new boolean field `private` in the index which is required to be `False` for in searches triggered by users without `ViewPrivate`
  - The text data list is split into a "public" and a "private" part (e.g. in case of private attributes of public objects). By using two different search schemas for users with and without `ViewPrivate`, both fields are searched or just one of them as appropriate. This makes sure no private information is leaked, but also no data has to be stored twice.

Furthermore, I added the last changed timestamp to the index which now allows date searches like
```
type:repository changed:'2012 to now'
```