### PR TITLE
Implement configurable internal links in HTML notes (fixes #122)

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -130,6 +130,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "formats": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
+            "format_options": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
             "profile": fields.DelimitedList(
@@ -190,6 +191,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "formats": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
+            "format_options": fields.Str(validate=validate.Length(min=1)),
             "gramps_id": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -525,7 +525,7 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
-    
+
 ##############################################################################
 # Endpoint - Families
 ##############################################################################
@@ -2431,6 +2431,17 @@ paths:
 
 
           html
+      - name: format_options
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined dictionary of options to be used by note formatters that must be provided in JSON format.
+
+          Possible keys in the JSON object:
+            Key | Description
+            --- | -------
+            link_format | Used by the 'html' formatter to format URLs to Gramps-internal links. Must be a template string that can contain '{obj_class}' (which will be replaced by, e.g, 'person'), '{gramps_id}', and '{handle}'.
       - name: rules
         in: query
         required: false
@@ -2545,6 +2556,17 @@ paths:
 
 
           html
+      - name: format_options
+        in: query
+        required: false
+        type: string
+        description: >
+          A user defined dictionary of options to be used by note formatters that must be provided in JSON format.
+
+          Possible keys in the JSON object:
+            Key | Description
+            --- | -------
+            link_format | Used by the 'html' formatter to format URLs to Gramps-internal links. Must be a template string that can contain '{obj_class}' (which will be replaced by, e.g, 'person'), '{gramps_id}', and '{handle}'.
       - name: strip
         in: query
         required: false
@@ -6271,7 +6293,7 @@ definitions:
         type: string
         example: Fernandez
 
-    
+
 ##############################################################################
 # Model - Types
 ##############################################################################
@@ -6285,7 +6307,7 @@ definitions:
       default:
         type: object
         $ref: "#/definitions/DefaultTypes"
-            
+
 ##############################################################################
 # Model - DefaultTypes
 ##############################################################################

--- a/tests/test_endpoints/test_notes.py
+++ b/tests/test_endpoints/test_notes.py
@@ -21,8 +21,10 @@
 
 """Tests for the /api/notes endpoints using example_gramps."""
 
+import json
 import re
 import unittest
+from urllib.parse import quote
 
 from . import BASE_URL, get_object_count, get_test_client
 from .checks import (
@@ -469,3 +471,22 @@ class TestNotesHandle(unittest.TestCase):
         # the HTML stripped of tags should be equal to the pure text string,
         # up to white space
         self.assertEqual(text_stripped, html_stripped)
+
+    def test_get_notes_link_format(self):
+        """Test formatting of internal links."""
+        options = {"link_format": "__{gramps_id}__{handle}__{obj_class}__"}
+        rv = check_success(
+            self,
+            "{}ac380498bac48eedee8?formats=html&format_options={}".format(
+                TEST_URL, quote(json.dumps(options))
+            ),
+        )
+        self.assertIn("formatted", rv)
+        self.assertIn("html", rv["formatted"])
+        html = rv["formatted"]["html"]
+        self.assertIsInstance(html, str)
+        self.assertIn(
+            '<a href="__I0044__GNUJQCL9MD64AM56OH__person__">Lewis Anderson Garner</a>',
+            html,
+        )
+


### PR DESCRIPTION
I implemented this now by adding a new option `format_options` on the note endpoint. It allows specifying a format string like e.g.

```
{"link_format": "{obj_class}/{gramps_id}"}
```
or
```
{"link_format": "http://myapp/objects/{obj_class}/{handle}"}
```

I decided against using `jinja2` for the time being ... it would allow additional modifications, but I think for apps that have special needs, it will anyway be necessary to do some post-processing. For instance, if an app uses a URL structure like narrative web, where event objects are under an `evt` URL, sources under `src`, etc., this would be very tricky to do even in `jinja`. But in that case I think it's simpler if the app uses a pattern like `__{obj_class}__` and then replaces `__event__` by `evt` etc.