### PR TITLE
Add /api/living endpoint

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -40,6 +40,7 @@ from .resources.exporters import (
 from .resources.facts import FactsResource
 from .resources.families import FamiliesResource, FamilyResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
+from .resources.living import LivingDatesResource, LivingResource
 from .resources.media import MediaObjectResource, MediaObjectsResource
 from .resources.metadata import MetadataResource
 from .resources.name_formats import NameFormatsResource
@@ -169,6 +170,9 @@ register_endpt(
     "/relations/<string:handle1>/<string:handle2>/all",
     "relations",
 )
+# Living
+register_endpt(LivingDatesResource, "/living/<string:handle>/dates", "living-dates")
+register_endpt(LivingResource, "/living/<string:handle>", "living")
 # Reports
 register_endpt(ReportFileResource, "/reports/<string:report_id>/file", "report-file")
 register_endpt(ReportResource, "/reports/<string:report_id>", "report")

--- a/gramps_webapi/api/resources/living.py
+++ b/gramps_webapi/api/resources/living.py
@@ -1,0 +1,110 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Living Calculator API Resource."""
+
+from typing import Dict
+
+from flask import Response, abort
+from gramps.gen.utils.alive import probably_alive, probably_alive_range
+from webargs import fields, validate
+
+from ...types import Handle
+from ..util import get_db_handle, get_locale_for_language, use_args
+from . import ProtectedResource
+from .emit import GrampsJSONEncoder
+from .util import get_person_by_handle
+
+
+class LivingResource(ProtectedResource, GrampsJSONEncoder):
+    """Living calculator resource."""
+
+    @use_args(
+        {
+            "average_generation_gap": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+            "max_age_probably_alive": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+            "max_sibling_age_difference": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+        },
+        location="query",
+    )
+    def get(self, args: Dict, handle: Handle) -> Response:
+        """Determine if person alive."""
+        db_handle = get_db_handle()
+        person = get_person_by_handle(db_handle, handle)
+        if person == {}:
+            abort(404)
+
+        data = probably_alive(
+            person,
+            db_handle,
+            max_sib_age_diff=args["max_sibling_age_difference"],
+            max_age_prob_alive=args["max_age_probably_alive"],
+            avg_generation_gap=args["average_generation_gap"],
+        )
+        return self.response(200, {"living": data})
+
+
+class LivingDatesResource(ProtectedResource, GrampsJSONEncoder):
+    """Living calculator dates resource."""
+
+    @use_args(
+        {
+            "average_generation_gap": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "max_age_probably_alive": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+            "max_sibling_age_difference": fields.Integer(
+                missing=None, validate=validate.Range(min=1)
+            ),
+        },
+        location="query",
+    )
+    def get(self, args: Dict, handle: Handle) -> Response:
+        """Determine estimated birth and death dates."""
+        db_handle = get_db_handle()
+        locale = get_locale_for_language(args["locale"], default=True)
+        person = get_person_by_handle(db_handle, handle)
+        if person == {}:
+            abort(404)
+
+        data = probably_alive_range(
+            person,
+            db_handle,
+            max_sib_age_diff=args["max_sibling_age_difference"],
+            max_age_prob_alive=args["max_age_probably_alive"],
+            avg_generation_gap=args["average_generation_gap"],
+        )
+
+        profile = {
+            "birth": locale.date_displayer.display(data[0]),
+            "death": locale.date_displayer.display(data[1]),
+            "explain": data[2],
+            "other": data[3],
+        }
+        return self.response(200, profile)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -60,6 +60,8 @@ tags:
   description: Work with translations.
 - name: relations
   description: Work with relationship calculator.
+- name: living
+  description: Work with living calculator.
 - name: timelines
   description: Work with timelines.
 - name: search
@@ -3847,6 +3849,105 @@ paths:
 
 
 ##############################################################################
+# Endpoint - Living
+##############################################################################
+
+  /living/{handle}:
+    get:
+      tags:
+      - living
+      summary: "Get whether or not a person is living."
+      operationId: getAlive
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        description: "The handle of the person to evaluate."
+      - name: average_generation_gap
+        in: query
+        required: false
+        type: integer
+        default: 20
+        description: "Average number of years between generations."
+      - name: max_age_probably_alive
+        in: query
+        required: false
+        type: integer
+        default: 110
+        description: "Maximum possible age in years someone could be considered alive."
+      - name: max_sibling_age_difference
+        in: query
+        required: false
+        type: integer
+        default: 20
+        description: "Maximum possible age difference in years between youngest and oldest sibling."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/Living"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Handle was not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+  /living/{handle}/dates:
+    get:
+      tags:
+      - living
+      summary: "Get estimated birth and death dates for a person."
+      operationId: getAliveDates
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        description: "The handle of the person to evaluate."
+      - name: average_generation_gap
+        in: query
+        required: false
+        type: integer
+        default: 20
+        description: "Average number of years between generations."
+      - name: max_age_probably_alive
+        in: query
+        required: false
+        type: integer
+        default: 110
+        description: "Maximum possible age in years someone could be considered alive."
+      - name: max_sibling_age_difference
+        in: query
+        required: false
+        type: integer
+        default: 20
+        description: "Maximum possible age difference in years between youngest and oldest sibling."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale for the date string if one other than the current default is desired."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/LivingDates"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Handle was not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+##############################################################################
 # Endpoint - Timelines
 ##############################################################################
 
@@ -7576,6 +7677,39 @@ definitions:
       score:
         type: number
         example: 5.522300827719273
+
+##############################################################################
+# Model - Living
+##############################################################################
+
+  Living:
+    type: object
+    properties:
+      living:
+        type: boolean
+        example: true
+
+##############################################################################
+# Model - LivingDates
+##############################################################################
+
+  LivingDates:
+    type: object
+    properties:
+      birth:
+        description: "Birth date or estimated birth date."
+        type: string
+        example: "1999-04-01"
+      death:
+         description: "Death date or estimated death date."
+         type: string
+         example: "2179-04-11"
+      explain:
+         description: "Explanation indicating how dates were arrived at."
+         type: string
+         example: "birth date"
+      other:
+        $ref: "#/definitions/Person"
 
 ##############################################################################
 # Model - TimelineEventProfile

--- a/tests/test_endpoints/test_facts.py
+++ b/tests/test_endpoints/test_facts.py
@@ -57,23 +57,8 @@ class TestFacts(unittest.TestCase):
     def test_get_records_expected_result(self):
         """Test expected response."""
         rv = check_success(self, TEST_URL)
-        self.assertEqual(
-            rv[0],
-            {
-                "description": "Youngest living person",
-                "key": "person_youngestliving",
-                "objects": [
-                    {
-                        "gramps_id": "I2044",
-                        "handle": "9BXKQC1PVLPYFMD6IX",
-                        "name": "Garner, Andrew Joseph",
-                        "object": "Person",
-                        "value": "21 years, 8 months, 11 days",
-                    }
-                ],
-            },
-        )
-
+        self.assertEqual(rv[0]["objects"][0]["handle"], "9BXKQC1PVLPYFMD6IX")
+        
     def test_get_records_parameter_locale_validate_semantics(self):
         """Test invalid locale parameter and values."""
         check_invalid_semantics(self, TEST_URL + "?locale", check="base")
@@ -82,7 +67,7 @@ class TestFacts(unittest.TestCase):
         """Test locale parameter."""
         rv = check_success(self, TEST_URL + "?locale=de")
         self.assertEqual(rv[0]["description"], "Jüngste lebende Person")
-        self.assertEqual(rv[0]["objects"][0]["value"], "21 Jahre, 8 Monate, 11 Tage")
+        self.assertIn("Jahre", rv[0]["objects"][0]["value"])
 
     def test_get_records_parameter_rank_validate_semantics(self):
         """Test invalid rank parameter and values."""

--- a/tests/test_endpoints/test_living.py
+++ b/tests/test_endpoints/test_living.py
@@ -1,0 +1,158 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for the /api/living endpoints using example_gramps."""
+
+import unittest
+
+from . import BASE_URL, get_test_client
+from .checks import (
+    check_conforms_to_schema,
+    check_invalid_semantics,
+    check_requires_token,
+    check_resource_missing,
+    check_success,
+)
+
+TEST_URL = BASE_URL + "/living/"
+
+
+class TestLiving(unittest.TestCase):
+    """Test cases for the /api/living/{handle} endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_get_living_requires_token(self):
+        """Test authorization required."""
+        check_requires_token(self, TEST_URL + "9BXKQC1PVLPYFMD6IX")
+
+    def test_get_living_expected_result(self):
+        """Test request produces expected result."""
+        rv = check_success(self, TEST_URL + "9BXKQC1PVLPYFMD6IX")
+        self.assertEqual(rv, {"living": True})
+
+    def test_get_living_missing_content(self):
+        """Test response for missing content."""
+        check_resource_missing(self, TEST_URL + "9BXKQC1PVLPYFMD6I")
+
+    def test_get_living_validate_semantics(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "9BXKQC1PVLPYFMD6IX?junk=1")
+
+    def test_get_living_parameter_average_generation_gap_validate_sematics(self):
+        """Test invalid average generation gap parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX?average_generation_gap",
+            check="number",
+        )
+
+    def test_get_living_parameter_max_age_probably_alive_validate_sematics(self):
+        """Test invalid max age probably alive parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX?max_age_probably_alive",
+            check="number",
+        )
+
+    def test_get_living_parameter_max_sibling_age_difference_validate_sematics(self):
+        """Test invalid max age probably alive parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX?max_age_probably_alive",
+            check="number",
+        )
+
+
+class TestLivingDates(unittest.TestCase):
+    """Test cases for the /api/living/{handle}/dates endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_get_living_dates_requires_token(self):
+        """Test authorization required."""
+        check_requires_token(self, TEST_URL + "9BXKQC1PVLPYFMD6IX/dates")
+
+    def test_get_living_dates_conforms_to_schema(self):
+        """Test conformity to schema."""
+        check_conforms_to_schema(
+            self, TEST_URL + "9BXKQC1PVLPYFMD6IX/dates", "LivingDates"
+        )
+
+    def test_get_living_dates_expected_result(self):
+        """Test response for valid request."""
+        rv = check_success(self, TEST_URL + "9BXKQC1PVLPYFMD6IX/dates")
+        self.assertEqual(rv["birth"], "1999-04-11")
+        self.assertEqual(rv["death"], "2109-04-11")
+        self.assertEqual(rv["explain"], "birth date")
+
+    def test_get_living_dates_missing_content(self):
+        """Test response for missing content."""
+        check_resource_missing(self, TEST_URL + "9BXKQC1PVLPYFMD6I/dates")
+
+    def test_get_living_dates_validate_semantics(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?junk=1")
+
+    def test_get_living_dates_parameter_average_generation_gap_validate_sematics(self):
+        """Test invalid average generation gap parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?average_generation_gap",
+            check="number",
+        )
+
+    def test_get_living_dates_parameter_max_age_probably_alive_validate_sematics(self):
+        """Test invalid max age probably alive parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?max_age_probably_alive",
+            check="number",
+        )
+
+    def test_get_living_dates_parameter_max_sibling_age_difference_validate_sematics(
+        self,
+    ):
+        """Test invalid max age probably alive parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?max_age_probably_alive",
+            check="number",
+        )
+
+    def test_get_living_dates_parameter_locale_validate_semantics(self):
+        """Test invalid locale parameter and values."""
+        check_invalid_semantics(
+            self,
+            TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?locale",
+            check="base",
+        )
+
+    def test_get_living_dates_parameter_locale_expected_result(self):
+        """Test locale parameter working as expected."""
+        rv = check_success(self, TEST_URL + "9BXKQC1PVLPYFMD6IX/dates?locale=de")
+        self.assertEqual(rv["birth"], "1999-04-11")
+        self.assertEqual(rv["death"], "2109-04-11")

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -501,77 +501,62 @@ class TestPeople(unittest.TestCase):
 
     def test_get_people_parameter_profile_expected_result(self):
         """Test expected response."""
-        rv = check_success(self, TEST_URL + "?page=1&profile=all")
+        rv = check_success(
+            self, TEST_URL + "?page=1&pagesize=1&keys=profile&strip=1&profile=all"
+        )
         self.assertEqual(
             rv[0]["profile"],
             {
-                "birth": {
-                    "age": "0 days",
-                    "date": "570-04-19",
-                    "place": "",
-                    "type": "Birth",
-                },
+                "birth": {"age": "0 days", "date": "570-04-19", "type": "Birth"},
                 "death": {
                     "age": "62 years, 1 months, 19 days",
                     "date": "632-06-08",
-                    "place": "",
                     "type": "Death",
                 },
                 "events": [
                     {
                         "age": "0 days",
                         "date": "570-04-19",
-                        "place": "",
+                        "role": "Primary",
                         "type": "Birth",
                     },
                     {
                         "age": "62 years, 1 months, 19 days",
                         "date": "632-06-08",
-                        "place": "",
+                        "role": "Primary",
                         "type": "Death",
                     },
                     {
                         "age": "39 years, 8 months, 13 days",
                         "date": "610",
-                        "place": "",
+                        "role": "Primary",
                         "type": "Marriage",
                     },
                 ],
                 "families": [
                     {
-                        "children": [],
-                        "divorce": {},
-                        "events": [],
-                        "family_surname": "",
                         "father": {
                             "birth": {
                                 "age": "0 days",
                                 "date": "570-04-19",
-                                "place": "",
                                 "type": "Birth",
                             },
                             "death": {
                                 "age": "62 years, 1 months, 19 days",
                                 "date": "632-06-08",
-                                "place": "",
                                 "type": "Death",
                             },
                             "gramps_id": "I2110",
                             "handle": "cc8205d872f532ab14e",
                             "name_given": "محمد",
-                            "name_surname": "",
                             "sex": "M",
                         },
                         "gramps_id": "F0743",
                         "handle": "cc8205d874433c12fd8",
-                        "marriage": {},
                         "mother": {
-                            "birth": {},
-                            "death": {},
                             "gramps_id": "I2105",
                             "handle": "cc8205d87831c772e87",
                             "name_given": "عائشة",
-                            "name_surname": "",
                             "sex": "F",
                         },
                         "relationship": "Married",
@@ -579,65 +564,46 @@ class TestPeople(unittest.TestCase):
                     {
                         "children": [
                             {
-                                "birth": {},
-                                "death": {},
                                 "gramps_id": "I2107",
                                 "handle": "cc8205d87fd529000ff",
                                 "name_given": "القاسم",
-                                "name_surname": "",
                                 "sex": "M",
                             },
                             {
-                                "birth": {},
-                                "death": {},
                                 "gramps_id": "I2108",
                                 "handle": "cc8205d883763f02abd",
                                 "name_given": "عبد الله",
-                                "name_surname": "",
                                 "sex": "M",
                             },
                             {
-                                "birth": {},
-                                "death": {},
                                 "gramps_id": "I2109",
                                 "handle": "cc8205d887376aacba2",
                                 "name_given": "أم كلثوم",
-                                "name_surname": "",
                                 "sex": "F",
                             },
                         ],
-                        "divorce": {},
-                        "events": [],
-                        "family_surname": "",
                         "father": {
                             "birth": {
                                 "age": "0 days",
                                 "date": "570-04-19",
-                                "place": "",
                                 "type": "Birth",
                             },
                             "death": {
                                 "age": "62 years, 1 months, 19 days",
                                 "date": "632-06-08",
-                                "place": "",
                                 "type": "Death",
                             },
                             "gramps_id": "I2110",
                             "handle": "cc8205d872f532ab14e",
                             "name_given": "محمد",
-                            "name_surname": "",
                             "sex": "M",
                         },
                         "gramps_id": "F0744",
                         "handle": "cc8205d87492b90b437",
-                        "marriage": {},
                         "mother": {
-                            "birth": {},
-                            "death": {},
                             "gramps_id": "I2106",
                             "handle": "cc8205d87c20350420b",
                             "name_given": "خديجة",
-                            "name_surname": "",
                             "sex": "F",
                         },
                         "relationship": "Married",
@@ -646,42 +612,23 @@ class TestPeople(unittest.TestCase):
                 "gramps_id": "I2110",
                 "handle": "cc8205d872f532ab14e",
                 "name_given": "محمد",
-                "name_surname": "",
-                "other_parent_families": [],
-                "primary_parent_family": {},
                 "references": {
                     "family": [
                         {
-                            "children": [],
-                            "divorce": {},
-                            "family_surname": "",
                             "father": {
-                                "birth": {
-                                    "date": "570-04-19",
-                                    "place": "",
-                                    "type": "Birth",
-                                },
-                                "death": {
-                                    "date": "632-06-08",
-                                    "place": "",
-                                    "type": "Death",
-                                },
+                                "birth": {"date": "570-04-19", "type": "Birth"},
+                                "death": {"date": "632-06-08", "type": "Death"},
                                 "gramps_id": "I2110",
                                 "handle": "cc8205d872f532ab14e",
                                 "name_given": "محمد",
-                                "name_surname": "",
                                 "sex": "M",
                             },
                             "gramps_id": "F0743",
                             "handle": "cc8205d874433c12fd8",
-                            "marriage": {},
                             "mother": {
-                                "birth": {},
-                                "death": {},
                                 "gramps_id": "I2105",
                                 "handle": "cc8205d87831c772e87",
                                 "name_given": "عائشة",
-                                "name_surname": "",
                                 "sex": "F",
                             },
                             "relationship": "Married",
@@ -689,62 +636,38 @@ class TestPeople(unittest.TestCase):
                         {
                             "children": [
                                 {
-                                    "birth": {},
-                                    "death": {},
                                     "gramps_id": "I2107",
                                     "handle": "cc8205d87fd529000ff",
                                     "name_given": "القاسم",
-                                    "name_surname": "",
                                     "sex": "M",
                                 },
                                 {
-                                    "birth": {},
-                                    "death": {},
                                     "gramps_id": "I2108",
                                     "handle": "cc8205d883763f02abd",
                                     "name_given": "عبد الله",
-                                    "name_surname": "",
                                     "sex": "M",
                                 },
                                 {
-                                    "birth": {},
-                                    "death": {},
                                     "gramps_id": "I2109",
                                     "handle": "cc8205d887376aacba2",
                                     "name_given": "أم كلثوم",
-                                    "name_surname": "",
                                     "sex": "F",
                                 },
                             ],
-                            "divorce": {},
-                            "family_surname": "",
                             "father": {
-                                "birth": {
-                                    "date": "570-04-19",
-                                    "place": "",
-                                    "type": "Birth",
-                                },
-                                "death": {
-                                    "date": "632-06-08",
-                                    "place": "",
-                                    "type": "Death",
-                                },
+                                "birth": {"date": "570-04-19", "type": "Birth"},
+                                "death": {"date": "632-06-08", "type": "Death"},
                                 "gramps_id": "I2110",
                                 "handle": "cc8205d872f532ab14e",
                                 "name_given": "محمد",
-                                "name_surname": "",
                                 "sex": "M",
                             },
                             "gramps_id": "F0744",
                             "handle": "cc8205d87492b90b437",
-                            "marriage": {},
                             "mother": {
-                                "birth": {},
-                                "death": {},
                                 "gramps_id": "I2106",
                                 "handle": "cc8205d87c20350420b",
                                 "name_given": "خديجة",
-                                "name_surname": "",
                                 "sex": "F",
                             },
                             "relationship": "Married",
@@ -752,48 +675,6 @@ class TestPeople(unittest.TestCase):
                     ]
                 },
                 "sex": "M",
-                "references": {
-                    "family": [
-                        {
-                            "children": [],
-                            "divorce": {},
-                            "events": [],
-                            "family_surname": "",
-                            "father": {
-                                "birth": {
-                                    "age": "0 days",
-                                    "date": "570-04-19",
-                                    "place": "",
-                                    "type": "Birth",
-                                },
-                                "death": {
-                                    "age": "62 years, 1 months, 19 days",
-                                    "date": "632-06-08",
-                                    "place": "",
-                                    "type": "Death",
-                                },
-                                "handle": "cc8205d872f532ab14e",
-                                "gramps_id": "I2110",
-                                "name_given": "محمد",
-                                "name_surname": "",
-                                "sex": "M",
-                            },
-                            "handle": "cc8205d874433c12fd8",
-                            "gramps_id": "F0743",
-                            "marriage": {},
-                            "mother": {
-                                "birth": {},
-                                "death": {},
-                                "handle": "cc8205d87831c772e87",
-                                "gramps_id": "I2105",
-                                "name_given": "عائشة",
-                                "name_surname": "",
-                                "sex": "F",
-                            },
-                            "relationship": "Married",
-                        },
-                    ]
-                },
             },
         )
 
@@ -1167,7 +1048,9 @@ class TestPeopleHandleTimeline(unittest.TestCase):
     def test_get_people_handle_timeline_conforms_to_schema(self):
         """Test conforms to schema."""
         check_conforms_to_schema(
-            self, TEST_URL + "GNUJQCL9MD64AM56OH/timeline", "TimelineEventProfile",
+            self,
+            TEST_URL + "GNUJQCL9MD64AM56OH/timeline",
+            "TimelineEventProfile",
         )
 
     def test_get_people_handle_timeline_missing_content(self):


### PR DESCRIPTION
@DavidMStraub this enhancement adds `/api/living/{handle}` and `/api/living/{handle}/dates` endpoints to provide access to the `ProbablyAlive` calculator in `gramps.gen.utils.alive`  It includes the `apispec.yaml` update and unit tests so unless you notice anything wrong should be ready to merge. 

I think maybe with this most of the core Gramps functionality is now exposed through the API.  The exceptions would be related to database and configuration management and the importers.

There is some kind of holiday calculator I noticed.  Maybe I'll add that too although I'm unsure how useful it may be outside of reports.

@Nick-Hall @romjerome have we missed anything that you have noticed that might be useful for a view only / presentation style application?